### PR TITLE
fixed module check for shared runtime between mga and federation module

### DIFF
--- a/ibmsecurity/appliance/isamappliance.py
+++ b/ibmsecurity/appliance/isamappliance.py
@@ -100,6 +100,9 @@ class ISAMAppliance(IBMAppliance):
             if uri.startswith("/wga"):
                 requires_modules = ['wga']
                 self.logger.debug("Detected module: {0} from uri: {1}.".format(requires_modules, uri))
+            elif uri.startswith("/mga/runtime_tuning") or uri.startswith("/mga/runtime_profile"):
+                requires_modules = ['mga','federation']
+                self.logger.debug("Detected module: {0} from uri: {1}.".format(requires_modules, uri))
             elif uri.startswith("/mga"):
                 requires_modules = ['mga']
                 self.logger.debug("Detected module: {0} from uri: {1}.".format(requires_modules, uri))


### PR DESCRIPTION
Although the mga runtime is shared between the mga and federation module, the check for required modules only resulted in `['mga']`. This pull request fixes the required modules check, so that accessing the mga runtime results in `['mga','federation']`.
Thus accessing the mga runtime is also possible if the federation module is used without the mga module.