### PR TITLE
Add name in log for certificate database creation

### DIFF
--- a/ibmsecurity/isam/base/ssl_certificates/certificate_databases.py
+++ b/ibmsecurity/isam/base/ssl_certificates/certificate_databases.py
@@ -30,7 +30,7 @@ def create(isamAppliance, kdb_name, type='kdb', token_label=None, passcode=None,
             return isamAppliance.create_return_object(changed=True)
         else:
             return isamAppliance.invoke_post(
-                "Creating a certificate database",
+                "Creating certificate database '{0}'".format(kdb_name),
                 "/isam/ssl_certificates",
                 {
                     "kdb_name": kdb_name,


### PR DESCRIPTION
Hi Ram,

I'm wondering if it would be worth including the name of the database being created. Perhaps there's a reason you've not already done this - would you mind cluing me in?

Cheers,
David