### PR TITLE
[DO NOT MERGE] Demonstrate fix for template file upload

### DIFF
--- a/ibmsecurity/appliance/isamappliance.py
+++ b/ibmsecurity/appliance/isamappliance.py
@@ -149,16 +149,15 @@ class ISAMAppliance(IBMAppliance):
             }
         self.logger.debug("Headers are: {0}".format(headers))
 
-        files = list()
-        for file2post in fileinfo:
-            files.append((file2post['file_formfield'],
-                          (file2post['filename'], open(file2post['filename'], 'rb'), file2post['mimetype'])))
+        files = {"file":
+                open(fileinfo, 'rb')}
 
         self._suppress_ssl_warning()
 
         try:
             r = requests.post(url=self._url(uri=uri), data=data, auth=(self.user.username, self.user.password),
                               files=files, verify=False, headers=headers)
+            self.logger.debug("Response: %i headers=%s", r.status_code, r.headers)
             return_obj['changed'] = True  # POST of file would be a change
             self._process_response(return_obj=return_obj, http_response=r, ignore_error=ignore_error)
 

--- a/ibmsecurity/isam/aac/runtime_template/root.py
+++ b/ibmsecurity/isam/aac/runtime_template/root.py
@@ -31,13 +31,7 @@ def import_file(isamAppliance, filename, check_mode=False, force=False):
         return isamAppliance.invoke_post_files(
             "Replace all Runtime Template Files",
             uri,
-            [
-                {
-                    'file_formfield': 'file',
-                    'filename': filename,
-                    'mimetype': 'application/octet-stream'
-                }
-            ],
+            filename,
             {
                 "force": force
             })


### PR DESCRIPTION
Hi Ram, template file zip upload doesn't work currently. I've hacked together something which makes it work, hoping that it can help to identify & fix the root issue.
Could you please explain - how is your post method used? It's more complicated than the equivalent pyisam call (see bottom of this message) and maybe does more.

It's possible that there's a small mistake in the original version of 'import_file' which you can fix quickly, but which I didn't figure out.

` ibmsecurity.isam.aac.runtime_template.root.import_file` is the method in question.

In a nutshell, this patch:
- Provides 'invoke_post_files' with one filename rather than a list of
files & metadata
- 'invoke_post_files' passes that file directly to 'requests'
- Doesn't add encoding etc manually, just trusts 'requests' library

For the 'replace all template files' zip upload, the RAPI doesn't
support multiple upload.

Based heavily on pyisam, which implements this RAPI call successfully:
https://github.ibm.com/benmarti/pyisam/blob/master/pyisam/core/access/templatefiles.py#L94-L111
https://github.ibm.com/benmarti/pyisam/blob/master/pyisam/util/restclient.py#L115-L130