### PR TITLE
Authentication policies search and update

### DIFF
--- a/ibmsecurity/appliance/isamappliance.py
+++ b/ibmsecurity/appliance/isamappliance.py
@@ -276,7 +276,7 @@ class ISAMAppliance(IBMAppliance):
 
         return return_obj
 
-    def _invoke_request(self, func, description, uri, ignore_error, data={}, requires_modules=None,
+    def _invoke_request(self, func, description, uri, ignore_error, data={}, parameters=None, requires_modules=None,
                         requires_version=None, warnings=[]):
         """
         Send a request to the LMI.  This function is private and should not be
@@ -308,11 +308,11 @@ class ISAMAppliance(IBMAppliance):
             if func == requests.get or func == requests.delete:
 
                 r = func(url=self._url(uri), auth=(self.user.username, self.user.password),
-                         verify=False, headers=headers)
+                         parameters=parameters, verify=False, headers=headers)
             else:
                 r = func(url=self._url(uri), data=json_data,
                          auth=(self.user.username, self.user.password),
-                         verify=False, headers=headers)
+                         parameters=parameters, verify=False, headers=headers)
 
             if func != requests.get:
                 return_obj['changed'] = True  # Anything but GET should result in change
@@ -342,13 +342,13 @@ class ISAMAppliance(IBMAppliance):
                                     requires_modules=requires_modules, requires_version=requires_version,
                                     warnings=warnings)
 
-    def invoke_get(self, description, uri, ignore_error=False, requires_modules=None, requires_version=None,
+    def invoke_get(self, description, uri, parameters=None, ignore_error=False, requires_modules=None, requires_version=None,
                    warnings=[]):
         """
         Send a GET request to the LMI.
         """
         return self._invoke_request(requests.get, description, uri, ignore_error, requires_modules=requires_modules,
-                                    requires_version=requires_version, warnings=warnings)
+                                    requires_version=requires_version, parameters=parameters, warnings=warnings)
 
     def invoke_delete(self, description, uri, ignore_error=False, requires_modules=None, requires_version=None,
                       warnings=[]):


### PR DESCRIPTION
(related to #27, which implements a core change required here)

Hey Ram, this one is API-breaking. I believe the existing .search and .update methods need to be more flexible, and unfortunately will not be backward-compatible.

---
Previously search accepted only a name.
Search now takes a filter, so scripts can search by parameters other
than name, and can combine parameters.
It returns the full result as before, a list of policies with all
their attributes.
However, as we can filter on non-unique attributes, the list may now
return multiple policies.

Update now takes an ID and a bunch of optional parameters to update.

Set has been modified to use the new update, but its behaviour is similar - it
searches purely on the name passed in.

Before:
search(isamAppliance, name) -> a ton of parameters
Then in the update request:
update(isamAppliance, name, <- all those parameters)

After:
search(isamAppliance, filter="name equals {}") or
search(isamAppliance, filter="uri equals {}") -> ID & others
Then in the update request:
update(isamAppliance, ID, description="foo", enabled=True)

This has the advantage of only setting parameters we wish to change, and
leaving the rest untouched.

I needed this for renaming a policy and updating some of its attributes.