### PR TITLE
Adding wait-functionality to reboot and restart functions

### DIFF
--- a/ibmsecurity/isam/appliance.py
+++ b/ibmsecurity/isam/appliance.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import time
+import ibmsecurity.isam.base.lmi
 
 logger = logging.getLogger(__name__)
 
@@ -84,6 +85,87 @@ def commit_and_restart(isamAppliance, check_mode=False, force=False):
                                              {})
     return isamAppliance.create_return_object()
 
+def reboot_and_wait(isamAppliance, wait_time=300, check_freq=5, check_mode=False, force=False):
+    """
+    Reboot and wait
+    :param isamAppliance:
+    :param wait_time:
+    :param check_freq:
+    :param check_mode:
+    :param force:
+    :return:
+    """
+    warnings = []
+    if check_mode is True:
+        return isamAppliance.create_return_object(changed=True)
+    else:
+        firmware = ibmsecurity.isam.base.firmware.get(isamAppliance, check_mode=check_mode, force=force)
+                
+        ret_obj = reboot(isamAppliance)
+        
+        if ret_obj['rc'] == 0:
+            sec = 0
+
+            # Now check if it is up and running
+            while 1:
+                ret_obj = ibmsecurity.isam.base.firmware.get(isamAppliance, check_mode=check_mode, force=force, ignore_error=True)
+
+                # check partition last_boot time
+                if ret_obj['rc'] == 0 and isinstance(ret_obj['data'], list) and len(ret_obj['data']) > 0 and \
+                    (('last_boot' in ret_obj['data'][0] and ret_obj['data'][0]['last_boot'] != firmware['data'][0]['last_boot'] and ret_obj['data'][0]['active'] == True) or ('last_boot' in ret_obj['data'][1] and ret_obj['data'][1]['last_boot'] != firmware['data'][1]['last_boot'] and ret_obj['data'][1]['active'] == True)):
+                    logger.info("Server is responding and has a different boot time!")
+                    return isamAppliance.create_return_object(warnings=warnings)
+                else:
+                    time.sleep(check_freq)
+                    sec += check_freq
+                    logger.debug("Server is not responding yet. Waited for {0} secs, next check in {1} secs.".format(sec, check_freq))
+
+                if sec >= wait_time:
+                    warnings.append("Server reboot not detected or completed, exiting... after {0} seconds".format(sec))
+                    break
+
+    return isamAppliance.create_return_object(warnings=warnings)
+
+def commit_and_restart_and_wait(isamAppliance, wait_time=300, check_freq=5, check_mode=False, force=False):
+    """
+    Restart LMI after commit
+    :param isamAppliance:
+    :param wait_time:
+    :param check_freq:
+    :param check_mode:
+    :param force:
+    :return:
+    """
+    warnings = []
+    if check_mode is True:
+        return isamAppliance.create_return_object(changed=True)
+    else:
+        lmi = ibmsecurity.isam.base.lmi.get(isamAppliance, check_mode=check_mode, force=force)
+                
+        ret_obj = commit_and_restart(isamAppliance)
+        
+        if ret_obj['rc'] == 0:
+            sec = 0
+
+            # Now check if it is up and running
+            while 1:
+                ret_obj = ibmsecurity.isam.base.lmi.get(isamAppliance, check_mode=check_mode, force=force)
+
+                # check partition last_boot time
+                if ret_obj['rc'] == 0 and isinstance(ret_obj['data'], list) and len(ret_obj['data']) > 0 and \
+                    ('start_time' in ret_obj['data'][0] and ret_obj['data'][0]['start_time'] != lmi['data'][0]['start_time']):
+                    logger.info("LMI is responding and has a different start time!")
+                    return isamAppliance.create_return_object(warnings=warnings)
+                else:
+                    time.sleep(check_freq)
+                    sec += check_freq
+                    logger.debug("LMI is not responding yet. Waited for {0} secs, next check in {1} secs.".format(sec, check_freq))
+
+                if sec >= wait_time:
+                    warnings.append("The LMI restart not detected or completed, exiting... after {0} seconds".format(sec))
+                    break
+
+    return isamAppliance.create_return_object(warnings=warnings)
 
 def rollback(isamAppliance, check_mode=False, force=False):
     """

--- a/ibmsecurity/isam/base/fips.py
+++ b/ibmsecurity/isam/base/fips.py
@@ -1,5 +1,6 @@
 import logging
 import ibmsecurity.utilities.tools
+import time
 
 logger = logging.getLogger(__name__)
 
@@ -49,6 +50,46 @@ def restart(isamAppliance, check_mode=False, force=False):
             {}
         )
 
+def restart_and_wait(isamAppliance, wait_time=300, check_freq=5, check_mode=False, force=False):
+    """
+    Restart after FIPS configuration changes
+    :param isamAppliance:
+    :param wait_time:
+    :param check_freq:
+    :param check_mode:
+    :param force:
+    :return:
+    """
+    warnings = []
+    if check_mode is True:
+        return isamAppliance.create_return_object(changed=True)
+    else:
+        firmware = ibmsecurity.isam.base.firmware.get(isamAppliance, check_mode=check_mode, force=force)
+                
+        ret_obj = restart(isamAppliance)
+        
+        if ret_obj['rc'] == 0:
+            sec = 0
+
+            # Now check if it is up and running
+            while 1:
+                ret_obj = ibmsecurity.isam.base.firmware.get(isamAppliance, check_mode=check_mode, force=force, ignore_error=True)
+
+                # check partition last_boot time
+                if ret_obj['rc'] == 0 and isinstance(ret_obj['data'], list) and len(ret_obj['data']) > 0 and \
+                    (('last_boot' in ret_obj['data'][0] and ret_obj['data'][0]['last_boot'] != firmware['data'][0]['last_boot'] and ret_obj['data'][0]['active'] == True) or ('last_boot' in ret_obj['data'][1] and ret_obj['data'][1]['last_boot'] != firmware['data'][1]['last_boot'] and ret_obj['data'][1]['active'] == True)):
+                    logger.info("Server is responding and has a different boot time!")
+                    return isamAppliance.create_return_object(warnings=warnings)
+                else:
+                    time.sleep(check_freq)
+                    sec += check_freq
+                    logger.debug("Server is not responding yet. Waited for {0} secs, next check in {1} secs.".format(sec, check_freq))
+
+                if sec >= wait_time:
+                    warnings.append("The FIPS restart not detected or completed, exiting... after {0} seconds".format(sec))
+                    break
+
+    return isamAppliance.create_return_object(warnings=warnings)
 
 def _check(isamAppliance, fipsEnabled, tlsv10Enabled, tlsv11Enabled):
     ret_obj = get(isamAppliance)

--- a/ibmsecurity/isam/base/firmware.py
+++ b/ibmsecurity/isam/base/firmware.py
@@ -4,12 +4,12 @@ import ibmsecurity.utilities.tools
 logger = logging.getLogger(__name__)
 
 
-def get(isamAppliance, check_mode=False, force=False):
+def get(isamAppliance, check_mode=False, force=False, ignore_error=False):
     """
     Retrieve existing firmware.
     """
     return isamAppliance.invoke_get("Retrieving firmware",
-                                    "/firmware_settings")
+                                    "/firmware_settings", ignore_error=ignore_error)
 
 
 def backup(isamAppliance, check_mode=False, force=False):

--- a/ibmsecurity/isam/base/lmi.py
+++ b/ibmsecurity/isam/base/lmi.py
@@ -65,3 +65,12 @@ def await_startup(isamAppliance, wait_time=300, check_freq=5, start_time=None, c
             break
 
     return isamAppliance.create_return_object(warnings=warnings)
+
+def restart_and_wait(isamAppliance, wait_time=300, check_freq=5, check_mode=False, force=False):
+    ret_obj = get(isamAppliance)
+    _start_time = ret_obj['data'][0]['start_time']
+    
+    restart(isamAppliance, check_mode, force)
+    
+    return await_startup(isamAppliance,wait_time=300, check_freq=5, start_time=_start_time, check_mode=False, force=False)
+


### PR DESCRIPTION
Adding additional functions ('*_and_wait') for restart and reboot functions to LMI, Appliance and FIPS scripts. For full support of wait-funtionality the 'ignore_error' parameter needed to be added to the firmware script.
The implementation depends on the script (LMI, appliance or FIPS) but follows a concept

1. call API (LMI or appliance endpoint) to retriev last timestamp ('start_time' or 'boot_time')
2. call restart or reboot function within the same script
3. repeat following task until successfull reply or timeout is hit:
3.1. call API (LMI or appliance endpoint) to retriev new timestamp
3.2. compare timestamps