### PR TITLE
Adding functionality: Set by address

### DIFF
--- a/ibmsecurity/isam/base/runtime/listening_interfaces.py
+++ b/ibmsecurity/isam/base/runtime/listening_interfaces.py
@@ -1,4 +1,5 @@
 import logging
+import ibmsecurity.isam.base.network.interfaces
 
 logger = logging.getLogger(__name__)
 requires_modules = ["mga", "federation"]
@@ -47,6 +48,21 @@ def set(isamAppliance, interface, port, secure, check_mode=False, force=False):
 
     return ret_obj
 
+def set_by_address(isamAppliance, address, port, secure,check_mode=False, force=False):
+    ret_obj = ibmsecurity.isam.base.network.interfaces.get_all(isamAppliance)
+    uuid = None
+
+    for intfc in ret_obj['data']['interfaces']:
+        for intfc_adr in intfc['ipv4']['addresses']:
+            if intfc_adr['address'] == address:
+                uuid = "{0}.{1}".format(intfc['uuid'],intfc_adr['uuid'])
+                break
+        for intfc_adr in intfc['ipv6']['addresses']:
+            if intfc_adr['address'] == address:
+                uuid = "{0}.{1}".format(intfc['uuid'],intfc_adr['uuid'])
+                break
+    
+    return set(isamAppliance, uuid, port, secure, check_mode, force)
 
 def _check(isamAppliance, interface, port):
     """


### PR DESCRIPTION
Adding function 'set_by_address' to set runtime listening interfaces by ip address. This function retrieves the uuid of the interface with the corresponding ip address (ipv4 or ipv6) and calls inner set function with necessary parameters.