### PR TITLE
Resolution to issue_83

### DIFF
--- a/ibmsecurity/isam/base/sysaccount/users.py
+++ b/ibmsecurity/isam/base/sysaccount/users.py
@@ -68,7 +68,7 @@ def delete(isamAppliance, id, check_mode=False, force=False):
     return isamAppliance.create_return_object()
 
 
-def modify(isamAppliance, id, password, old_password, check_mode=False, force=False):
+def modify(isamAppliance, id, password, old_password=None, check_mode=False, force=False):
     """
     Change a users password
     """
@@ -78,8 +78,7 @@ def modify(isamAppliance, id, password, old_password, check_mode=False, force=Fa
         else:
             return isamAppliance.invoke_put("Change password", "/sysaccount/users/{0}/v1".format(id),
                                             {
-                                                'password': password,
-                                                'old_password': old_password
+                                                'password': password
                                             })
 
     return isamAppliance.create_return_object()


### PR DESCRIPTION
Please review and consider for merge.

I took the suggested approach of setting the parameter 'old_password'  = None of the method "modify".
This will ensure the parameter is no longer mandatory.
Also, the new code is making sure that parameter 'old_password' is not used at all since it is useless for the given api.