### PR TITLE
export_file returned a JSON instead of the file

### DIFF
--- a/ibmsecurity/isam/aac/runtime_template/file.py
+++ b/ibmsecurity/isam/aac/runtime_template/file.py
@@ -174,7 +174,7 @@ def export_file(isamAppliance, path, name, filename, check_mode=False, force=Fal
         if check_mode is False:
             return isamAppliance.invoke_get_file(
                 "Exporting a file from the runtime template files directory",
-                "/mga/template_files/{0}/{1}?type=File".format(path, name), filename)
+                "/mga/template_files/{0}/{1}?type=File&export=true".format(path, name), filename)
 
     return isamAppliance.create_return_object()
 


### PR DESCRIPTION
Appended the export=true url parameter so that the LMI returns a file instead of a JSON structure containing a file. This was tested on 9.0.4.