### PR TITLE
Resolution to issue_106

### DIFF
--- a/ibmsecurity/isam/aac/server_connections/ws.py
+++ b/ibmsecurity/isam/aac/server_connections/ws.py
@@ -22,10 +22,11 @@ def get(isamAppliance, name=None, check_mode=False, force=False):
     """
     Retrieving a Web Service connection
     """
-    ret_obj = _get_id(isamAppliance, name=name)
-    id = ret_obj['data']
-
+    ret_obj = search(isamAppliance, name=name, force=force)
+    id = ret_obj["data"]
+    
     if id == {}:
+        logger.info("Web Service connection {0} had no match, skipping retrieval.".format(name))
         return isamAppliance.create_return_object()
     else:
         return isamAppliance.invoke_get("Retrieving a Web Service connection",
@@ -34,18 +35,21 @@ def get(isamAppliance, name=None, check_mode=False, force=False):
                                         requires_version=requires_version)
 
 
-def set(isamAppliance, name, connection, description='', locked=False, servers=None,
-        check_mode=False, force=False):
+def search(isamAppliance, name, check_mode=False, force=False):
     """
-    Creating or Modifying a Web Service connection
+    Search UUID for named Web Service connection
     """
-    if _check_exists(isamAppliance, name=name) is False:
-        # Force the add - we already know connection does not exist
-        return add(isamAppliance, name, connection, description, locked, servers, check_mode, True)
-    else:
-        # Update request
-        return update(isamAppliance, connection, description, locked, servers, name, None,
-                      check_mode, force)
+    ret_obj = get_all(isamAppliance)
+    return_obj = isamAppliance.create_return_object()
+    return_obj["warnings"] = ret_obj["warnings"]
+
+    for obj in ret_obj['data']:
+        if obj['name'] == name:
+            logger.info("Found Web Service connection {0} id: {1}".format(name, obj['uuid']))
+            return_obj['data'] = obj['uuid']
+            return_obj['rc'] = 0
+
+    return return_obj
 
 
 def add(isamAppliance, name, connection, description='', locked=False, servers=None,
@@ -53,16 +57,15 @@ def add(isamAppliance, name, connection, description='', locked=False, servers=N
     """
     Creating a Web Service connection
     """
-    if force is True or _check_exists(isamAppliance, name=name) is False:
+    if (search(isamAppliance, name=name))['data'] == {}:
         if check_mode is True:
             return isamAppliance.create_return_object(changed=True)
         else:
             return isamAppliance.invoke_post(
                 "Creating a Web Service connection",
                 "{0}/v1".format(uri),
-                _create_json(name=name, description=description, locked=locked, servers=servers,
-                             connection=connection), requires_modules=requires_modules,
-                requires_version=requires_version)
+                _create_json(name=name, description=description, locked=locked, connection=connection), 
+                    requires_modules=requires_modules, requires_version=requires_version)
 
     return isamAppliance.create_return_object()
 
@@ -71,19 +74,23 @@ def delete(isamAppliance, name=None, check_mode=False, force=False):
     """
     Deleting a Web Service connection
     """
-    if force is True or _check_exists(isamAppliance, name=name) is True:
+    ret_obj = search(isamAppliance, name, check_mode=check_mode, force=force)
+    id = ret_obj["data"]
+    warnings = ret_obj["warnings"]
+
+    if id == {}:
+        logger.info("Web Service connection {0} not found, skipping delete.".format(name))
+    else:
         if check_mode is True:
-            return isamAppliance.create_return_object(changed=True)
+            return isamAppliance.create_return_object(changed=True, warnings=warnings)
         else:
-            ret_obj = _get_id(isamAppliance, name=name)
-            id = ret_obj['data']
             return isamAppliance.invoke_delete(
                 "Deleting a Web Service connection",
                 "{0}/{1}/v1".format(uri, id), requires_modules=requires_modules,
-                requires_version=requires_version)
+                requires_version=requires_version, warnings=warnings)
 
-    return isamAppliance.create_return_object()
-
+    return isamAppliance.create_return_object(warnings=warnings)
+        
 
 def update(isamAppliance, connection, description='', locked=False, servers=None, name=None,
            new_name=None, check_mode=False, force=False):
@@ -92,23 +99,64 @@ def update(isamAppliance, connection, description='', locked=False, servers=None
 
     Use new_name to rename the connection
     """
-    if check_mode is True:
-        return isamAppliance.create_return_object(changed=True)
+    ret_obj = get(isamAppliance, name)
+    warnings = ret_obj["warnings"]
+    
+    if ret_obj["data"] == {}:
+        warnings.append("Web Service connection {0} not found, skipping update.".format(name))
+        return isamAppliance.create_return_object(warnings=warnings)
     else:
-        json_data = _create_json(name=name, description=description, locked=locked, servers=servers,
-                                 connection=connection)
-        if new_name is not None:  # Rename condition
-            json_data['name'] = new_name
-        return isamAppliance.invoke_put(
-            "Modifying a Web Service connection",
-            "{0}/{1}/v1".format(uri, id), json_data, requires_modules=requires_modules,
-            requires_version=requires_version)
+        id = ret_obj["data"]["uuid"]
+        
+    needs_update = False
 
+    json_data = _create_json(name=name, description=description, locked=locked, connection=connection)
+    if new_name is not None:  # Rename condition
+        json_data['name'] = new_name
 
-def _create_json(name, description, locked, servers, connection):
+    if force is not True:
+        if 'uuid' in ret_obj['data']:
+           del ret_obj['data']['uuid']
+
+        import ibmsecurity.utilities.tools        
+
+        if ibmsecurity.utilities.tools.json_sort(ret_obj['data']) != ibmsecurity.utilities.tools.json_sort(
+                json_data):
+            needs_update = True
+    
+        if 'password' in connection:
+            warnings.append("Since existing password cannot be read - this call will not be idempotent.")
+            needs_update = True
+
+    if force is True or needs_update is True:
+        if check_mode is True:
+            return isamAppliance.create_return_object(changed=True, warnings=warnings)
+        else:
+            return isamAppliance.invoke_put(
+                "Modifying a Web Service connection",
+                "{0}/{1}/v1".format(uri, id), json_data, requires_modules=requires_modules,
+                requires_version=requires_version,warnings=warnings)
+    
+    return isamAppliance.create_return_object(warnings=warnings)
+
+def set(isamAppliance, name, connection, description='', locked=False, servers=None,
+        check_mode=False, force=False):
+    """
+    Creating or Modifying a Web Service connection
+    """
+    if (search(isamAppliance, name=name))['data'] == {}:
+        # Force the add - we already know connection does not exist
+        return add(isamAppliance, name, connection, description, locked, servers, check_mode, True)
+    else:
+        # Update request
+        return update(isamAppliance, connection, description, locked, servers, name, None,
+                      check_mode, force)
+
+def _create_json(name, description, locked, connection):
     """
     Create a JSON to be used for the REST API call
     """
+
     json = {
         "connection": connection,
         "type": "ws",
@@ -116,39 +164,8 @@ def _create_json(name, description, locked, servers, connection):
         "description": description,
         "locked": locked
     }
-    # servers is optional
-    if servers is not None:
-        json['servers'] = servers
 
     return json
-
-
-def _get_id(isamAppliance, name):
-    """
-    Retrieve UUID for named Web Service connection
-    """
-    ret_obj = get_all(isamAppliance)
-
-    ret_obj_new = isamAppliance.create_return_object()
-
-    for obj in ret_obj['data']:
-        if obj['name'] == name:
-            ret_obj_new['data'] = obj['uuid']
-
-    return ret_obj_new
-
-
-def _check_exists(isamAppliance, name=None, id=None):
-    """
-    Check if Web Service connection already exists
-    """
-    ret_obj = get_all(isamAppliance)
-
-    for obj in ret_obj['data']:
-        if (name is not None and obj['name'] == name) or (id is not None and obj['uuid'] == id):
-            return True
-
-    return False
 
 
 def compare(isamAppliance1, isamAppliance2):


### PR DESCRIPTION
Important Notice - major code overhaul:
a)	Made the parameter ‘server’ useless. Oversight from original author of this code (me!!!) who forgot to remove this parameter from the method signatures when creating ws.py code from ldap.py. It is too late to remove altogether this parameter from the method signature, but I made just at least it was nowhere in the code.
b)	Re-organise the code to have the now somewhat standard methods: “search/add/delete/update/set”.
c)	Fix the set() method that was not comparing old&new values before issuing an HTTP PUT.
d)	However, if the parameter ‘password’ is passed in the ‘connection’ object then a warning is logged and the HTTP PUT on the server connection is enforced.
Tested many combinations:
•	Method add() on new connection (OK: created connection)
•	Method add() on existing connection (OK: skipped)
•	Method set() on new connection (OK: created connection)
•	Method set () on existing connection (OK: tried updating connection)
•	Method set () on existing connection with ‘password’ passed in connection object (OK: enforce updates on connection)
