### PR TITLE
Resolution to issue_108

### DIFF
--- a/ibmsecurity/isam/aac/api_protection/clients.py
+++ b/ibmsecurity/isam/aac/api_protection/clients.py
@@ -290,12 +290,13 @@ def update(isamAppliance, name, definitionName, companyName, redirectUri=None, c
                 json_data["jwksUri"] = jwksUri
         elif 'jwksUri' in ret_obj['data']:
             del ret_obj['data']['jwksUri']
+
         sorted_ret_obj = tools.json_sort(ret_obj['data'])
         sorted_json_data = tools.json_sort(json_data)
+        logger.debug("Sorted Existing Data:{0}".format(sorted_ret_obj))
+        logger.debug("Sorted Desired  Data:{0}".format(sorted_json_data))
         if sorted_ret_obj != sorted_json_data:
             needs_update = True
-            logger.debug("Sorted Existing Data:{0}".format(sorted_ret_obj))
-            logger.debug("Sorted Desired  Data:{0}".format(sorted_json_data))
 
     if force is True or needs_update is True:
         if check_mode is True:

--- a/ibmsecurity/isam/aac/api_protection/definitions.py
+++ b/ibmsecurity/isam/aac/api_protection/definitions.py
@@ -221,9 +221,11 @@ def update(isamAppliance, name, description="", grantTypes=["AUTHORIZATION_CODE"
                 if 'enc' in ret_obj['data']['oidc']['enc'] and ret_obj['data']['oidc']['enc']['enc'] is None:
                     del ret_obj['data']['oidc']['enc']['enc']
 
-        import ibmsecurity.utilities.tools
-        if ibmsecurity.utilities.tools.json_sort(ret_obj['data']) != ibmsecurity.utilities.tools.json_sort(
-                json_data):
+        sorted_ret_obj = tools.json_sort(ret_obj['data'])
+        sorted_json_data = tools.json_sort(json_data)
+        logger.debug("Sorted Existing Data:{0}".format(sorted_ret_obj))
+        logger.debug("Sorted Desired  Data:{0}".format(sorted_json_data))
+        if sorted_ret_obj != sorted_json_data:
             needs_update = True
 
     if force is True or needs_update is True:

--- a/ibmsecurity/isam/aac/api_protection/definitions.py
+++ b/ibmsecurity/isam/aac/api_protection/definitions.py
@@ -178,10 +178,12 @@ def update(isamAppliance, name, description="", grantTypes=["AUTHORIZATION_CODE"
             warnings.append(
                 "Appliance at version: {0}, oidc: {1} is not supported. Needs 9.0.4.0 or higher. Ignoring oidc for this call.".format(
                     isamAppliance.facts["version"], oidc))
+            oidc = None
         else:
             json_data["oidc"] = oidc
 
     if force is not True:
+
         if 'datecreated' in ret_obj['data']:
             del ret_obj['data']['datecreated']
         if 'id' in ret_obj['data']:
@@ -190,6 +192,35 @@ def update(isamAppliance, name, description="", grantTypes=["AUTHORIZATION_CODE"
             del ret_obj['data']['lastmodified']
         if 'mappingRules' in ret_obj['data']:
             del ret_obj['data']['mappingRules']
+
+        # Inspecting oidcConfig and remove missing or None attributes in returned object
+        if oidc is not None and 'oidc' in ret_obj['data']:
+            if 'enabled' in ret_obj['data']['oidc'] and ret_obj['data']['oidc']['enabled'] is None:
+                del ret_obj['data']['oidc']['enabled']
+            if 'iss' in ret_obj['data']['oidc'] and ret_obj['data']['oidc']['iss'] is None:
+                del ret_obj['data']['oidc']['iss']
+            if 'poc' in ret_obj['data']['oidc'] and ret_obj['data']['oidc']['poc'] is None:
+                del ret_obj['data']['oidc']['poc']
+            if 'lifetime' in ret_obj['data']['oidc'] and ret_obj['data']['oidc']['lifetime'] is None:
+                del ret_obj['data']['oidc']['lifetime']
+            if 'alg' in ret_obj['data']['oidc'] and ret_obj['data']['oidc']['alg'] is None:
+                del ret_obj['data']['oidc']['alg']
+            if 'db' in ret_obj['data']['oidc'] and ret_obj['data']['oidc']['db'] is None:
+                del ret_obj['data']['oidc']['db']
+            if 'cert' in ret_obj['data']['oidc'] and ret_obj['data']['oidc']['cert'] is None:
+                del ret_obj['data']['oidc']['cert']
+            if 'attributeSources' in ret_obj['data']['oidc'] and ret_obj['data']['oidc']['attributeSources'] is None:
+                del ret_obj['data']['oidc']['attributeSources']
+
+            # Inspecting oidcEncConfig and remove missing or None attributes in returned object
+            if 'enc' in ret_obj['data']['oidc'] and ret_obj['data']['oidc']['enc'] is not None:
+                if 'enabled' in ret_obj['data']['oidc']['enc'] and ret_obj['data']['oidc']['enc']['enabled'] is None:
+                    del ret_obj['data']['oidc']['enc']['enabled']
+                if 'alg' in ret_obj['data']['oidc']['enc'] and ret_obj['data']['oidc']['enc']['alg'] is None:
+                    del ret_obj['data']['oidc']['enc']['alg']
+                if 'enc' in ret_obj['data']['oidc']['enc'] and ret_obj['data']['oidc']['enc']['enc'] is None:
+                    del ret_obj['data']['oidc']['enc']['enc']
+
         import ibmsecurity.utilities.tools
         if ibmsecurity.utilities.tools.json_sort(ret_obj['data']) != ibmsecurity.utilities.tools.json_sort(
                 json_data):

--- a/ibmsecurity/isam/aac/server_connections/ws.py
+++ b/ibmsecurity/isam/aac/server_connections/ws.py
@@ -52,8 +52,7 @@ def search(isamAppliance, name, check_mode=False, force=False):
     return return_obj
 
 
-def add(isamAppliance, name, connection, description='', locked=False, servers=None,
-        check_mode=False, force=False):
+def add(isamAppliance, name, connection, description='', locked=False, check_mode=False, force=False):
     """
     Creating a Web Service connection
     """
@@ -92,8 +91,8 @@ def delete(isamAppliance, name=None, check_mode=False, force=False):
     return isamAppliance.create_return_object(warnings=warnings)
         
 
-def update(isamAppliance, connection, description='', locked=False, servers=None, name=None,
-           new_name=None, check_mode=False, force=False):
+def update(isamAppliance, connection, description='', locked=False, name=None, new_name=None, 
+	check_mode=False, force=False):
     """
     Modifying a Web Service connection
 
@@ -139,17 +138,16 @@ def update(isamAppliance, connection, description='', locked=False, servers=None
     
     return isamAppliance.create_return_object(warnings=warnings)
 
-def set(isamAppliance, name, connection, description='', locked=False, servers=None,
-        check_mode=False, force=False):
+def set(isamAppliance, name, connection, description='', locked=False, check_mode=False, force=False):
     """
     Creating or Modifying a Web Service connection
     """
     if (search(isamAppliance, name=name))['data'] == {}:
         # Force the add - we already know connection does not exist
-        return add(isamAppliance, name, connection, description, locked, servers, check_mode, True)
+        return add(isamAppliance, name, connection, description, locked, check_mode, True)
     else:
         # Update request
-        return update(isamAppliance, connection, description, locked, servers, name, None,
+        return update(isamAppliance, connection, description, locked, name, None,
                       check_mode, force)
 
 def _create_json(name, description, locked, connection):

--- a/ibmsecurity/isam/aac/server_connections/ws.py
+++ b/ibmsecurity/isam/aac/server_connections/ws.py
@@ -1,5 +1,5 @@
 import logging
-import ibmsecurity.utilities.tools
+from ibmsecurity.utilities import tools
 
 logger = logging.getLogger(__name__)
 
@@ -117,10 +117,11 @@ def update(isamAppliance, connection, description='', locked=False, name=None, n
         if 'uuid' in ret_obj['data']:
            del ret_obj['data']['uuid']
 
-        import ibmsecurity.utilities.tools        
-
-        if ibmsecurity.utilities.tools.json_sort(ret_obj['data']) != ibmsecurity.utilities.tools.json_sort(
-                json_data):
+        sorted_ret_obj = tools.json_sort(ret_obj['data'])
+        sorted_json_data = tools.json_sort(json_data)
+        logger.debug("Sorted Existing Data:{0}".format(sorted_ret_obj))
+        logger.debug("Sorted Desired  Data:{0}".format(sorted_json_data))
+        if sorted_ret_obj != sorted_json_data:
             needs_update = True
     
         if 'password' in connection:


### PR DESCRIPTION
-Add logic on method update() to perform inspection on API definition oidcConfig and oidcEncConfig sub-structures
-Should they contain 'None' value, remove them before performing comparison of old&ew values

This resolve idempotency behavior when updates were always turning out as HTTP PUT to the appliance although no changes were pushed by playbook.  Because this particular code has complexdata structure, I am putting here a sample YML contant:


    - role: set_oauth_definition ( ***** role to be submitted/updated eventually after this PR is reviewed and merged ***** )
      oauth_definition_file: "{{ ansible_env.ISAM_TEMPLATES_HOME }}/isam/aac/{{ fact_serverassetinfo_environment }}/api_protection/{{ set_oauth_definition_name }}.properties"
      set_oauth_definition_grantTypes: ["AUTHORIZATION_CODE"]
      set_oauth_definition_tcmBehavior: "NEVER_PROMPT"
      set_oauth_definition_accessTokenLifetime: 1500
      set_oauth_definition_enforceSingleAccessTokenPerGrant: True
      set_oauth_definition_enforceSingleUseAuthorizationGrant: True
      set_oauth_definition_refreshTokenLength: 500
      set_oauth_definition_maxAuthorizationGrantLifetime: 15552000
      oauth_definition_oidc_web_host: "{{ lookup('ini', 'add_oauth_definition_oidc_web_host type=properties file={{ oauth_definition_file }}') }}"
      oauth_definition_oidc_iss: "https://{{ oauth_definition_oidc_web_host }}"
      oauth_definition_oidc_poc: "https://{{ oauth_definition_oidc_web_host }}/isam"
      oauth_definition_oidc_lifetime: 1500
      oauth_definition_oidc_db: "{{ lookup('ini', 'add_oauth_definition_oidc_db type=properties file={{ oauth_definition_file }}') }}"
      oauth_definition_oidc_cert: "{{ lookup('ini', 'add_oauth_definition_oidc_cert type=properties file={{ oauth_definition_file }}') }}"
      oauth_definition_oidc_attrs: [{ "attributeName":"test1", "attributeSourceId":"1" },{ "attributeName":"test2", "attributeSourceId":"1" }]
      set_oauth_definition_oidc: { "enabled": True, "alg": "RS256", "db": "{{ oauth_definition_oidc_db }}", "cert": "{{ oauth_definition_oidc_cert}}", "iss": "{{ oauth_definition_oidc_iss }}", "poc": "{{ oauth_definition_oidc_poc }}", "lifetime": "{{ oauth_definition_oidc_lifetime }}", "enc":{ "enabled":False }, "attributeSources": "{{ oauth_definition_oidc_attrs }}" }
