### PR TITLE
Features: 4, BugFixes: 4, Typos: 1

### DIFF
--- a/ibmsecurity/isam/aac/api_protection/clients.py
+++ b/ibmsecurity/isam/aac/api_protection/clients.py
@@ -6,7 +6,7 @@ logger = logging.getLogger(__name__)
 
 # URI for this module
 uri = "/iam/access/v8/clients"
-requires_modules = ["mga"]
+requires_modules = ["mga", "federation"]
 requires_version = None
 
 
@@ -75,8 +75,7 @@ def generate_client_secret(isamAppliance, check_mode=False, force=False):
 
 
 def add(isamAppliance, name, definitionName, companyName, redirectUri=None, companyUrl=None, contactPerson=None,
-        contactType=None, email=None, phone=None, otherInfo=None, clientId=None, clientSecret=None,
-        requirePkce=None, encryptionDb=None, encryptionCert=None, jwksUri=None, check_mode=False,
+        contactType=None, email=None, phone=None, otherInfo=None, clientId=None, clientSecret=None, encryptionDb=None, encryptionCert=None, jwksUri=None, requirePkce=False, check_mode=False,
         force=False):
     """
     Create an API protection definition
@@ -122,6 +121,14 @@ def add(isamAppliance, name, definitionName, companyName, redirectUri=None, comp
                 client_json["clientId"] = clientId
             if clientSecret is not None:
                 client_json["clientSecret"] = clientSecret
+            if encryptionDb is not None:
+                client_json["encryptionDb"] = encryptionDb
+            if encryptionCert is not None:
+                client_json["encryptionCert"] = encryptionCert
+            if jwksUri is not None:
+                client_json["jwksUri"] = jwksUri
+            if requirePkce is not None:
+                client_json["requirePkce"] = requirePkce
             if requirePkce is not None:
                 if tools.version_compare(isamAppliance.facts["version"], "9.0.4.0") < 0:
                     warnings.append(
@@ -180,8 +187,7 @@ def delete(isamAppliance, name, check_mode=False, force=False):
 
 
 def update(isamAppliance, name, definitionName, companyName, redirectUri=None, companyUrl=None, contactPerson=None,
-           contactType=None, email=None, phone=None, otherInfo=None, clientId=None, clientSecret=None,
-           requirePkce=None, encryptionDb=None, encryptionCert=None, jwksUri=None, check_mode=False,
+           contactType=None, email=None, phone=None, otherInfo=None, clientId=None, clientSecret=None, encryptionDb=None, encryptionCert=None, jwksUri=None, requirePkce=False, check_mode=False,
            force=False, new_name=None):
     """
     Update a specified mapping rule
@@ -254,6 +260,26 @@ def update(isamAppliance, name, definitionName, companyName, redirectUri=None, c
             json_data["clientSecret"] = clientSecret
         elif 'clientSecret' in ret_obj['data']:
             del ret_obj['data']['clientSecret']
+        if encryptionDb is not None:
+            json_data["encryptionDb"] = encryptionDb
+        elif 'encryptionDb' in ret_obj['data']:
+            del ret_obj['data']['encryptionDb']
+        if encryptionCert is not None:
+            json_data["encryptionCert"] = encryptionCert
+        elif 'encryptionCert' in ret_obj['data']:
+            del ret_obj['data']['encryptionCert']
+        if jwksUri is not None:
+            json_data["jwksUri"] = jwksUri
+        elif 'jwksUri' in ret_obj['data']:
+            del ret_obj['data']['jwksUri']
+        if requirePkce is not None:
+            json_data["requirePkce"] = requirePkce
+        elif 'requirePkce' in ret_obj['data']:
+            del ret_obj['data']['requirePkce']
+        if tools.json_sort(ret_obj['data']) != tools.json_sort(json_data):
+            needs_update = True
+        logger.info("Definition on the server: {0}".format(ret_obj['data']))
+        logger.info("Desired configuration: {0}".format(json_data))
         if requirePkce is not None:
             if tools.version_compare(isamAppliance.facts["version"], "9.0.4.0") < 0:
                 warnings.append(
@@ -309,8 +335,8 @@ def update(isamAppliance, name, definitionName, companyName, redirectUri=None, c
 
 
 def set(isamAppliance, name, definitionName, companyName, redirectUri=None, companyUrl=None, contactPerson=None,
-        contactType=None, email=None, phone=None, otherInfo=None, clientId=None, clientSecret=None, new_name=None,
-        requirePkce=None, encryptionDb=None, encryptionCert=None, jwksUri=None, check_mode=False,
+        contactType=None, email=None, phone=None, otherInfo=None, clientId=None, clientSecret=None, new_name=None, encryptionDb=None, encryptionCert=None, jwksUri=None, requirePkce=False,
+        check_mode=False,
         force=False):
     """
     Creating or Modifying an API Protection Definition
@@ -319,18 +345,16 @@ def set(isamAppliance, name, definitionName, companyName, redirectUri=None, comp
         # Force the add - we already know policy does not exist
         logger.info("Definition {0} had no match, requesting to add new one.".format(name))
         return add(isamAppliance, name, definitionName, companyName, redirectUri=redirectUri, companyUrl=companyUrl,
-                   contactPerson=contactPerson, contactType=contactType, email=email, phone=phone, otherInfo=otherInfo,
-                   clientId=clientId, clientSecret=clientSecret, requirePkce=requirePkce, encryptionDb=encryptionDb,
-                   encryptionCert=encryptionCert, jwksUri=jwksUri, check_mode=check_mode, force=True)
+                   contactPerson=contactPerson,
+                   contactType=contactType, email=email, phone=phone, otherInfo=otherInfo, clientId=clientId,
+                   clientSecret=clientSecret, encryptionDb=encryptionDb, encryptionCert=encryptionCert, jwksUri=jwksUri, requirePkce=requirePkce, check_mode=check_mode, force=True)
     else:
         # Update request
         logger.info("Definition {0} exists, requesting to update.".format(name))
         return update(isamAppliance, name, definitionName, companyName, redirectUri=redirectUri, companyUrl=companyUrl,
                       contactPerson=contactPerson, contactType=contactType, email=email, phone=phone,
-                      otherInfo=otherInfo, clientId=clientId, clientSecret=clientSecret, new_name=new_name,
-                      requirePkce=requirePkce, encryptionDb=encryptionDb, encryptionCert=encryptionCert,
-                      jwksUri=jwksUri, check_mode=check_mode, force=force)
-
+                      otherInfo=otherInfo, clientId=clientId, clientSecret=clientSecret, new_name=new_name, encryptionDb=encryptionDb, encryptionCert=encryptionCert, jwksUri=jwksUri, requirePkce=requirePkce,
+                      check_mode=check_mode, force=force)
 
 def compare(isamAppliance1, isamAppliance2):
     """

--- a/ibmsecurity/isam/aac/api_protection/definitions.py
+++ b/ibmsecurity/isam/aac/api_protection/definitions.py
@@ -5,7 +5,7 @@ logger = logging.getLogger(__name__)
 
 # URI for this module
 uri = "/iam/access/v8/definitions"
-requires_modules = ["mga"]
+requires_modules = ["mga", "federation"]
 requires_version = None
 
 

--- a/ibmsecurity/isam/aac/runtime_template/root.py
+++ b/ibmsecurity/isam/aac/runtime_template/root.py
@@ -1,4 +1,7 @@
 import logging
+import os.path
+from ibmsecurity.isam.aac.runtime_template import directory
+from ibmsecurity.isam.aac.runtime_template import file
 
 logger = logging.getLogger(__name__)
 
@@ -41,3 +44,41 @@ def import_file(isamAppliance, filename, check_mode=False, force=False):
             {
                 "force": force
             }, json_response=False)
+
+def check(isamAppliance, id, type, check_mode=False, force=False):
+  ret_obj = None
+  
+  if(type.lower() == 'directory'):
+    ret_obj = directory._check(isamAppliance, id)
+  elif(type.lower() == 'file'):
+    ret_obj = file._check(isamAppliance, id)
+  else:
+    type = 'unknown'
+
+  name = os.path.basename(id)
+  path = os.path.dirname(id)
+  
+  data = {
+      'id': ret_obj,
+      'path': path,
+      'name': name,
+      'type': type
+  }
+    
+  return isamAppliance.create_return_object(data=data)
+
+def delete(isamAppliance, id, type, check_mode=False, force=False):
+    """
+    Deleting a file or directory in the runtime template files directory
+
+    :param isamAppliance:
+    :param id:
+    :param_type:
+    :param check_mode:
+    :param force:
+    :return:
+    """
+    if(type.lower() == 'directory'):
+      return directory.delete(isamAppliance, id)
+    elif(type.lower() == 'file'):
+      return file.delete(isamAppliance, id)

--- a/ibmsecurity/isam/web/reverse_proxy/management_root/all.py
+++ b/ibmsecurity/isam/web/reverse_proxy/management_root/all.py
@@ -1,6 +1,8 @@
 import logging
 import ibmsecurity.utilities.tools
 import os.path
+from ibmsecurity.isam.web.reverse_proxy.management_root import directory
+from ibmsecurity.isam.web.reverse_proxy.management_root import file
 
 logger = logging.getLogger(__name__)
 
@@ -47,3 +49,22 @@ def import_zip(isamAppliance, instance_id, filename, check_mode=False, force=Fal
                 'type': 'file',
                 'force': force
             })
+            
+def check(isamAppliance, instance_id, id, name, type, check_mode=False, force=False):
+  ret_obj = None
+  
+  if(type.lower() == 'directory'):
+    ret_obj = directory._check(isamAppliance, instance_id, id, name)
+  elif(type.lower() == 'file'):
+    ret_obj = file._check(isamAppliance, instance_id, id, name)
+  else:
+    type = 'unknown'
+
+  data = {
+      'id': ret_obj,
+      'top': id,
+      'name': name,
+      'type': type
+  }
+    
+  return isamAppliance.create_return_object(data=data)

--- a/ibmsecurity/isam/web/reverse_proxy/management_root/file.py
+++ b/ibmsecurity/isam/web/reverse_proxy/management_root/file.py
@@ -239,7 +239,7 @@ def _check_import(isamAppliance, instance_id, id, filename, check_mode=False):
     """
     tmpdir = get_random_temp_dir()
     tmp_original_file = os.path.join(tmpdir, os.path.basename(id))
-    if _check(isamAppliance, instance_id, id, ''):
+    if (_check(isamAppliance, instance_id, id, '') is not None):
         export_file(isamAppliance, instance_id, id, tmp_original_file, check_mode=False, force=True)
         logger.debug("file already exists on appliance")
         if files_same(tmp_original_file, filename):

--- a/ibmsecurity/isam/web/reverse_proxy/oauth_configuration.py
+++ b/ibmsecurity/isam/web/reverse_proxy/oauth_configuration.py
@@ -15,7 +15,7 @@ def config(isamAppliance, instance_id, hostname='127.0.0.1', port=443, username=
 
     :param isamAppliance:
     :param instance_id:
-	:param junction:
+    :param junction:
     :param hostname:
     :param port:
     :param username:


### PR DESCRIPTION
Feature:
- sts module chains [idempotency]: idempotency: before comparison of server and client configuration properties with keyword 'password' are ignored (only for comparison) for self and partner configuration inside _check function
- sts module chains [search]:  search for map rule reference ids (Introduction of new property "map.rule.reference.names" inside properties object. This property triggers search for map rule reference ids and adding this instead of the "map.rule.reference.names" property as ".map.rule.reference.ids" property. A prefix parameter for "map.rule.reference.names" is necessary to search properly for the mapping rule (therefore self-selected prefix should be considered for mapping rule creation)
- management_root [all.py]: check function to call file or directory check of corresponding sub classes. Includes some more return data than just the object id (id=object id, top=top level id[e.g. errors, management, junction_root], name=object name that was checked, type=object type [file, directory, unknown]
- runtime_template: adding _parse_id function for propper return of _check function
- cluster configuration: idempotency (To achiev idempotency for cluster configuration all parameter with word 'password' should be ignored for comparission of local and server configuration)

BugFix
- api_protection: New parameter (encryptionDb, encryptionCert, jwksUri, requirePkce)
- cluster_configuration:  if you want to configure remote hvdb the parameter hvdb_max_size is not necessary and therefore shouldn't be a default of '40'
- runtime_template: check function in directory and file class not properly checking if file exists for other function calls. Function parameters harmonization: get, _check, create, update, delete, rename, compare, export_file, import_file, _check_import for file and directory class
- management_root [file.py]: for _check_import function it was possible to have a object id of 1 leading to a false positive check that the file already existed on the server.

Typo: indent on oauth_configuration