### PR TITLE
Features: 4, BugFixes: 3, Typos: 1

### DIFF
--- a/ibmsecurity/isam/aac/api_protection/clients.py
+++ b/ibmsecurity/isam/aac/api_protection/clients.py
@@ -75,7 +75,8 @@ def generate_client_secret(isamAppliance, check_mode=False, force=False):
 
 
 def add(isamAppliance, name, definitionName, companyName, redirectUri=None, companyUrl=None, contactPerson=None,
-        contactType=None, email=None, phone=None, otherInfo=None, clientId=None, clientSecret=None, encryptionDb=None, encryptionCert=None, jwksUri=None, requirePkce=False, check_mode=False,
+        contactType=None, email=None, phone=None, otherInfo=None, clientId=None, clientSecret=None,
+        requirePkce=None, encryptionDb=None, encryptionCert=None, jwksUri=None, check_mode=False,
         force=False):
     """
     Create an API protection definition
@@ -121,14 +122,6 @@ def add(isamAppliance, name, definitionName, companyName, redirectUri=None, comp
                 client_json["clientId"] = clientId
             if clientSecret is not None:
                 client_json["clientSecret"] = clientSecret
-            if encryptionDb is not None:
-                client_json["encryptionDb"] = encryptionDb
-            if encryptionCert is not None:
-                client_json["encryptionCert"] = encryptionCert
-            if jwksUri is not None:
-                client_json["jwksUri"] = jwksUri
-            if requirePkce is not None:
-                client_json["requirePkce"] = requirePkce
             if requirePkce is not None:
                 if tools.version_compare(isamAppliance.facts["version"], "9.0.4.0") < 0:
                     warnings.append(
@@ -187,7 +180,8 @@ def delete(isamAppliance, name, check_mode=False, force=False):
 
 
 def update(isamAppliance, name, definitionName, companyName, redirectUri=None, companyUrl=None, contactPerson=None,
-           contactType=None, email=None, phone=None, otherInfo=None, clientId=None, clientSecret=None, encryptionDb=None, encryptionCert=None, jwksUri=None, requirePkce=False, check_mode=False,
+           contactType=None, email=None, phone=None, otherInfo=None, clientId=None, clientSecret=None,
+           requirePkce=None, encryptionDb=None, encryptionCert=None, jwksUri=None, check_mode=False,
            force=False, new_name=None):
     """
     Update a specified mapping rule
@@ -260,26 +254,6 @@ def update(isamAppliance, name, definitionName, companyName, redirectUri=None, c
             json_data["clientSecret"] = clientSecret
         elif 'clientSecret' in ret_obj['data']:
             del ret_obj['data']['clientSecret']
-        if encryptionDb is not None:
-            json_data["encryptionDb"] = encryptionDb
-        elif 'encryptionDb' in ret_obj['data']:
-            del ret_obj['data']['encryptionDb']
-        if encryptionCert is not None:
-            json_data["encryptionCert"] = encryptionCert
-        elif 'encryptionCert' in ret_obj['data']:
-            del ret_obj['data']['encryptionCert']
-        if jwksUri is not None:
-            json_data["jwksUri"] = jwksUri
-        elif 'jwksUri' in ret_obj['data']:
-            del ret_obj['data']['jwksUri']
-        if requirePkce is not None:
-            json_data["requirePkce"] = requirePkce
-        elif 'requirePkce' in ret_obj['data']:
-            del ret_obj['data']['requirePkce']
-        if tools.json_sort(ret_obj['data']) != tools.json_sort(json_data):
-            needs_update = True
-        logger.info("Definition on the server: {0}".format(ret_obj['data']))
-        logger.info("Desired configuration: {0}".format(json_data))
         if requirePkce is not None:
             if tools.version_compare(isamAppliance.facts["version"], "9.0.4.0") < 0:
                 warnings.append(
@@ -336,8 +310,8 @@ def update(isamAppliance, name, definitionName, companyName, redirectUri=None, c
 
 
 def set(isamAppliance, name, definitionName, companyName, redirectUri=None, companyUrl=None, contactPerson=None,
-        contactType=None, email=None, phone=None, otherInfo=None, clientId=None, clientSecret=None, new_name=None, encryptionDb=None, encryptionCert=None, jwksUri=None, requirePkce=False,
-        check_mode=False,
+        contactType=None, email=None, phone=None, otherInfo=None, clientId=None, clientSecret=None, new_name=None,
+        requirePkce=None, encryptionDb=None, encryptionCert=None, jwksUri=None, check_mode=False,
         force=False):
     """
     Creating or Modifying an API Protection Definition
@@ -346,16 +320,17 @@ def set(isamAppliance, name, definitionName, companyName, redirectUri=None, comp
         # Force the add - we already know policy does not exist
         logger.info("Definition {0} had no match, requesting to add new one.".format(name))
         return add(isamAppliance, name, definitionName, companyName, redirectUri=redirectUri, companyUrl=companyUrl,
-                   contactPerson=contactPerson,
-                   contactType=contactType, email=email, phone=phone, otherInfo=otherInfo, clientId=clientId,
-                   clientSecret=clientSecret, encryptionDb=encryptionDb, encryptionCert=encryptionCert, jwksUri=jwksUri, requirePkce=requirePkce, check_mode=check_mode, force=True)
+                   contactPerson=contactPerson, contactType=contactType, email=email, phone=phone, otherInfo=otherInfo,
+                   clientId=clientId, clientSecret=clientSecret, requirePkce=requirePkce, encryptionDb=encryptionDb,
+                   encryptionCert=encryptionCert, jwksUri=jwksUri, check_mode=check_mode, force=True)
     else:
         # Update request
         logger.info("Definition {0} exists, requesting to update.".format(name))
         return update(isamAppliance, name, definitionName, companyName, redirectUri=redirectUri, companyUrl=companyUrl,
                       contactPerson=contactPerson, contactType=contactType, email=email, phone=phone,
-                      otherInfo=otherInfo, clientId=clientId, clientSecret=clientSecret, new_name=new_name, encryptionDb=encryptionDb, encryptionCert=encryptionCert, jwksUri=jwksUri, requirePkce=requirePkce,
-                      check_mode=check_mode, force=force)
+                      otherInfo=otherInfo, clientId=clientId, clientSecret=clientSecret, new_name=new_name,
+                      requirePkce=requirePkce, encryptionDb=encryptionDb, encryptionCert=encryptionCert,
+                      jwksUri=jwksUri, check_mode=check_mode, force=force)
 
 def compare(isamAppliance1, isamAppliance2):
     """

--- a/ibmsecurity/isam/aac/api_protection/clients.py
+++ b/ibmsecurity/isam/aac/api_protection/clients.py
@@ -6,7 +6,7 @@ logger = logging.getLogger(__name__)
 
 # URI for this module
 uri = "/iam/access/v8/clients"
-requires_modules = ["mga"]
+requires_modules = ["mga", "federation"]
 requires_version = None
 
 
@@ -75,8 +75,7 @@ def generate_client_secret(isamAppliance, check_mode=False, force=False):
 
 
 def add(isamAppliance, name, definitionName, companyName, redirectUri=None, companyUrl=None, contactPerson=None,
-        contactType=None, email=None, phone=None, otherInfo=None, clientId=None, clientSecret=None,
-        requirePkce=None, encryptionDb=None, encryptionCert=None, jwksUri=None, check_mode=False,
+        contactType=None, email=None, phone=None, otherInfo=None, clientId=None, clientSecret=None, encryptionDb=None, encryptionCert=None, jwksUri=None, requirePkce=False, check_mode=False,
         force=False):
     """
     Create an API protection definition
@@ -122,6 +121,14 @@ def add(isamAppliance, name, definitionName, companyName, redirectUri=None, comp
                 client_json["clientId"] = clientId
             if clientSecret is not None:
                 client_json["clientSecret"] = clientSecret
+            if encryptionDb is not None:
+                client_json["encryptionDb"] = encryptionDb
+            if encryptionCert is not None:
+                client_json["encryptionCert"] = encryptionCert
+            if jwksUri is not None:
+                client_json["jwksUri"] = jwksUri
+            if requirePkce is not None:
+                client_json["requirePkce"] = requirePkce
             if requirePkce is not None:
                 if tools.version_compare(isamAppliance.facts["version"], "9.0.4.0") < 0:
                     warnings.append(
@@ -180,8 +187,7 @@ def delete(isamAppliance, name, check_mode=False, force=False):
 
 
 def update(isamAppliance, name, definitionName, companyName, redirectUri=None, companyUrl=None, contactPerson=None,
-           contactType=None, email=None, phone=None, otherInfo=None, clientId=None, clientSecret=None,
-           requirePkce=None, encryptionDb=None, encryptionCert=None, jwksUri=None, check_mode=False,
+           contactType=None, email=None, phone=None, otherInfo=None, clientId=None, clientSecret=None, encryptionDb=None, encryptionCert=None, jwksUri=None, requirePkce=False, check_mode=False,
            force=False, new_name=None):
     """
     Update a specified mapping rule
@@ -254,6 +260,26 @@ def update(isamAppliance, name, definitionName, companyName, redirectUri=None, c
             json_data["clientSecret"] = clientSecret
         elif 'clientSecret' in ret_obj['data']:
             del ret_obj['data']['clientSecret']
+        if encryptionDb is not None:
+            json_data["encryptionDb"] = encryptionDb
+        elif 'encryptionDb' in ret_obj['data']:
+            del ret_obj['data']['encryptionDb']
+        if encryptionCert is not None:
+            json_data["encryptionCert"] = encryptionCert
+        elif 'encryptionCert' in ret_obj['data']:
+            del ret_obj['data']['encryptionCert']
+        if jwksUri is not None:
+            json_data["jwksUri"] = jwksUri
+        elif 'jwksUri' in ret_obj['data']:
+            del ret_obj['data']['jwksUri']
+        if requirePkce is not None:
+            json_data["requirePkce"] = requirePkce
+        elif 'requirePkce' in ret_obj['data']:
+            del ret_obj['data']['requirePkce']
+        if tools.json_sort(ret_obj['data']) != tools.json_sort(json_data):
+            needs_update = True
+        logger.info("Definition on the server: {0}".format(ret_obj['data']))
+        logger.info("Desired configuration: {0}".format(json_data))
         if requirePkce is not None:
             if tools.version_compare(isamAppliance.facts["version"], "9.0.4.0") < 0:
                 warnings.append(
@@ -309,8 +335,8 @@ def update(isamAppliance, name, definitionName, companyName, redirectUri=None, c
 
 
 def set(isamAppliance, name, definitionName, companyName, redirectUri=None, companyUrl=None, contactPerson=None,
-        contactType=None, email=None, phone=None, otherInfo=None, clientId=None, clientSecret=None, new_name=None,
-        requirePkce=None, encryptionDb=None, encryptionCert=None, jwksUri=None, check_mode=False,
+        contactType=None, email=None, phone=None, otherInfo=None, clientId=None, clientSecret=None, new_name=None, encryptionDb=None, encryptionCert=None, jwksUri=None, requirePkce=False,
+        check_mode=False,
         force=False):
     """
     Creating or Modifying an API Protection Definition
@@ -319,18 +345,16 @@ def set(isamAppliance, name, definitionName, companyName, redirectUri=None, comp
         # Force the add - we already know policy does not exist
         logger.info("Definition {0} had no match, requesting to add new one.".format(name))
         return add(isamAppliance, name, definitionName, companyName, redirectUri=redirectUri, companyUrl=companyUrl,
-                   contactPerson=contactPerson, contactType=contactType, email=email, phone=phone, otherInfo=otherInfo,
-                   clientId=clientId, clientSecret=clientSecret, requirePkce=requirePkce, encryptionDb=encryptionDb,
-                   encryptionCert=encryptionCert, jwksUri=jwksUri, check_mode=check_mode, force=True)
+                   contactPerson=contactPerson,
+                   contactType=contactType, email=email, phone=phone, otherInfo=otherInfo, clientId=clientId,
+                   clientSecret=clientSecret, encryptionDb=encryptionDb, encryptionCert=encryptionCert, jwksUri=jwksUri, requirePkce=requirePkce, check_mode=check_mode, force=True)
     else:
         # Update request
         logger.info("Definition {0} exists, requesting to update.".format(name))
         return update(isamAppliance, name, definitionName, companyName, redirectUri=redirectUri, companyUrl=companyUrl,
                       contactPerson=contactPerson, contactType=contactType, email=email, phone=phone,
-                      otherInfo=otherInfo, clientId=clientId, clientSecret=clientSecret, new_name=new_name,
-                      requirePkce=requirePkce, encryptionDb=encryptionDb, encryptionCert=encryptionCert,
-                      jwksUri=jwksUri, check_mode=check_mode, force=force)
-
+                      otherInfo=otherInfo, clientId=clientId, clientSecret=clientSecret, new_name=new_name, encryptionDb=encryptionDb, encryptionCert=encryptionCert, jwksUri=jwksUri, requirePkce=requirePkce,
+                      check_mode=check_mode, force=force)
 
 def compare(isamAppliance1, isamAppliance2):
     """

--- a/ibmsecurity/isam/aac/api_protection/clients.py
+++ b/ibmsecurity/isam/aac/api_protection/clients.py
@@ -76,7 +76,7 @@ def generate_client_secret(isamAppliance, check_mode=False, force=False):
 
 def add(isamAppliance, name, definitionName, companyName, redirectUri=None, companyUrl=None, contactPerson=None,
         contactType=None, email=None, phone=None, otherInfo=None, clientId=None, clientSecret=None,
-        requirePkce=None, encryptionDb=None, encryptionCert=None, jwksUri=None, check_mode=False,
+        requirePkce=None, encryptionDb=None, encryptionCert=None, jwksUri=None, extProperties=None, check_mode=False,
         force=False):
     """
     Create an API protection definition
@@ -150,6 +150,13 @@ def add(isamAppliance, name, definitionName, companyName, redirectUri=None, comp
                             isamAppliance.facts["version"], jwksUri))
                 else:
                     client_json["jwksUri"] = jwksUri
+            if extProperties is not None:
+                if tools.version_compare(isamAppliance.facts["version"], "9.0.5.0") < 0:
+                    warnings.append(
+                        "Appliance at version: {0}, extProperties: {1} is not supported. Needs 9.0.5.0 or higher. Ignoring extProperties for this call.".format(
+                            isamAppliance.facts["version"], extProperties))
+                else:
+                    client_json["extProperties"] = extProperties
 
             return isamAppliance.invoke_post(
                 "Create an API protection definition", uri, client_json, requires_modules=requires_modules,
@@ -181,7 +188,7 @@ def delete(isamAppliance, name, check_mode=False, force=False):
 
 def update(isamAppliance, name, definitionName, companyName, redirectUri=None, companyUrl=None, contactPerson=None,
            contactType=None, email=None, phone=None, otherInfo=None, clientId=None, clientSecret=None,
-           requirePkce=None, encryptionDb=None, encryptionCert=None, jwksUri=None, check_mode=False,
+           requirePkce=None, encryptionDb=None, encryptionCert=None, jwksUri=None, extProperties=None, check_mode=False,
            force=False, new_name=None):
     """
     Update a specified mapping rule
@@ -290,6 +297,15 @@ def update(isamAppliance, name, definitionName, companyName, redirectUri=None, c
                 json_data["jwksUri"] = jwksUri
         elif 'jwksUri' in ret_obj['data']:
             del ret_obj['data']['jwksUri']
+        if extProperties is not None:
+            if tools.version_compare(isamAppliance.facts["version"], "9.0.5.0") < 0:
+                warnings.append(
+                    "Appliance at version: {0}, extProperties: {1} is not supported. Needs 9.0.5.0 or higher. Ignoring extProperties for this call.".format(
+                        isamAppliance.facts["version"], extProperties))
+            else:
+                json_data["extProperties"] = extProperties
+        elif 'extProperties' in ret_obj['data']:
+            del ret_obj['data']['extProperties']
 
         sorted_ret_obj = tools.json_sort(ret_obj['data'])
         sorted_json_data = tools.json_sort(json_data)
@@ -311,7 +327,7 @@ def update(isamAppliance, name, definitionName, companyName, redirectUri=None, c
 
 def set(isamAppliance, name, definitionName, companyName, redirectUri=None, companyUrl=None, contactPerson=None,
         contactType=None, email=None, phone=None, otherInfo=None, clientId=None, clientSecret=None, new_name=None,
-        requirePkce=None, encryptionDb=None, encryptionCert=None, jwksUri=None, check_mode=False,
+        requirePkce=None, encryptionDb=None, encryptionCert=None, jwksUri=None, extProperties=None, check_mode=False,
         force=False):
     """
     Creating or Modifying an API Protection Definition
@@ -322,7 +338,7 @@ def set(isamAppliance, name, definitionName, companyName, redirectUri=None, comp
         return add(isamAppliance, name, definitionName, companyName, redirectUri=redirectUri, companyUrl=companyUrl,
                    contactPerson=contactPerson, contactType=contactType, email=email, phone=phone, otherInfo=otherInfo,
                    clientId=clientId, clientSecret=clientSecret, requirePkce=requirePkce, encryptionDb=encryptionDb,
-                   encryptionCert=encryptionCert, jwksUri=jwksUri, check_mode=check_mode, force=True)
+                   encryptionCert=encryptionCert, jwksUri=jwksUri, extProperties=extProperties, check_mode=check_mode, force=True)
     else:
         # Update request
         logger.info("Definition {0} exists, requesting to update.".format(name))
@@ -330,7 +346,7 @@ def set(isamAppliance, name, definitionName, companyName, redirectUri=None, comp
                       contactPerson=contactPerson, contactType=contactType, email=email, phone=phone,
                       otherInfo=otherInfo, clientId=clientId, clientSecret=clientSecret, new_name=new_name,
                       requirePkce=requirePkce, encryptionDb=encryptionDb, encryptionCert=encryptionCert,
-                      jwksUri=jwksUri, check_mode=check_mode, force=force)
+                      jwksUri=jwksUri, extProperties=extProperties, check_mode=check_mode, force=force)
 
 def compare(isamAppliance1, isamAppliance2):
     """

--- a/ibmsecurity/isam/aac/api_protection/definitions.py
+++ b/ibmsecurity/isam/aac/api_protection/definitions.py
@@ -5,7 +5,7 @@ logger = logging.getLogger(__name__)
 
 # URI for this module
 uri = "/iam/access/v8/definitions"
-requires_modules = ["mga"]
+requires_modules = ["mga", "federation"]
 requires_version = None
 
 

--- a/ibmsecurity/isam/aac/runtime_template/directory.py
+++ b/ibmsecurity/isam/aac/runtime_template/directory.py
@@ -84,6 +84,40 @@ def create(isamAppliance, path, name, check_mode=False, force=False):
 
     return isamAppliance.create_return_object(warnings=warnings)
 
+def create(isamAppliance, id, check_mode=False, force=False):
+    """
+    Creating a directory in the runtime template files directory
+
+    :param isamAppliance:
+    :param id:
+    :param name:
+    :param check_mode:
+    :param force:
+    :return:
+    """
+    warnings = []
+    
+    path = os.path.dirname(id)
+    name = os.path.basename(id)
+    
+    check_dir = _check(isamAppliance, id)
+    if check_dir != None:
+        warnings.append("Directory {0} exists. Ignoring create.".format(id))
+
+    if force is True or check_dir == None:
+        if check_mode is True:          
+            return isamAppliance.create_return_object(changed=True, warnings=warnings)
+        else:
+            return isamAppliance.invoke_post(
+                "Creating a directory in the runtime template files directory",
+                "/mga/template_files/{0}".format(path),
+                {
+                    'dir_name': name,
+                    'type': 'dir'
+                })
+
+    return isamAppliance.create_return_object(warnings=warnings)
+
 
 def delete(isamAppliance, id, check_mode=False, force=False):
     """

--- a/ibmsecurity/isam/aac/runtime_template/file.py
+++ b/ibmsecurity/isam/aac/runtime_template/file.py
@@ -235,7 +235,7 @@ def _check_import(isamAppliance, id, filename, check_mode=False):
     """   
     tmpdir = get_random_temp_dir()
     tmp_original_file = os.path.join(tmpdir, os.path.basename(id))
-    if _check(isamAppliance, id):
+    if _check(isamAppliance, id) != None:
         export_file(isamAppliance, id, tmp_original_file, check_mode=False, force=True)
         logger.debug("file already exists on appliance")
         if files_same(tmp_original_file, filename):

--- a/ibmsecurity/isam/aac/runtime_template/root.py
+++ b/ibmsecurity/isam/aac/runtime_template/root.py
@@ -1,4 +1,7 @@
 import logging
+import os.path
+from ibmsecurity.isam.aac.runtime_template import directory
+from ibmsecurity.isam.aac.runtime_template import file
 
 logger = logging.getLogger(__name__)
 
@@ -41,3 +44,41 @@ def import_file(isamAppliance, filename, check_mode=False, force=False):
             {
                 "force": force
             }, json_response=False)
+
+def check(isamAppliance, id, type, check_mode=False, force=False):
+  ret_obj = None
+  
+  if(type.lower() == 'directory'):
+    ret_obj = directory._check(isamAppliance, id)
+  elif(type.lower() == 'file'):
+    ret_obj = file._check(isamAppliance, id)
+  else:
+    type = 'unknown'
+
+  name = os.path.basename(id)
+  path = os.path.dirname(id)
+  
+  data = {
+      'id': ret_obj,
+      'path': path,
+      'name': name,
+      'type': type
+  }
+    
+  return isamAppliance.create_return_object(data=data)
+
+def delete(isamAppliance, id, type, check_mode=False, force=False):
+    """
+    Deleting a file or directory in the runtime template files directory
+
+    :param isamAppliance:
+    :param id:
+    :param_type:
+    :param check_mode:
+    :param force:
+    :return:
+    """
+    if(type.lower() == 'directory'):
+      return directory.delete(isamAppliance, id)
+    elif(type.lower() == 'file'):
+      return file.delete(isamAppliance, id)

--- a/ibmsecurity/isam/aac/runtime_template/root.py
+++ b/ibmsecurity/isam/aac/runtime_template/root.py
@@ -79,6 +79,6 @@ def delete(isamAppliance, id, type, check_mode=False, force=False):
     :return:
     """
     if(type.lower() == 'directory'):
-      return directory.delete(isamAppliance, id)
+      return directory.delete(isamAppliance, id, check_mode, force)
     elif(type.lower() == 'file'):
-      return file.delete(isamAppliance, id)
+      return file.delete(isamAppliance, id, check_mode, force)

--- a/ibmsecurity/isam/base/snapshots.py
+++ b/ibmsecurity/isam/base/snapshots.py
@@ -102,10 +102,27 @@ def delete(isamAppliance, id, check_mode=False, force=False):
 
     return isamAppliance.create_return_object()
 
-    # Logic to delete multiple snapshots - may need to be coded later
-    #    uri = "/snapshots/multi_destroy?record_ids=" + ",".join(ids)
-    #    return isamAppliance.invoke_delete("Deleting multiple snapshots", uri);
+def multi_delete(isamAppliance, ids=[], comment=None, check_mode=False, force=False):
+    """
+    Delete multiple snapshots based on id or comment
+    """
+    if comment != None:
+      ret_obj = search(isamAppliance, comment=comment)
+      if ret_obj['data'] == {}:
+        return isamAppliance.create_return_object(changed=False)
+      else:
+        if ids == []:
+          ids = ret_obj['data']
+        else:
+          for snaps in ret_obj['data']:
+            ids.append(snaps)
 
+    if check_mode is True:
+        return isamAppliance.create_return_object(changed=True)
+    else:
+        return isamAppliance.invoke_delete("Deleting one or multiple snapshots", "/snapshots/multi_destroy?record_ids=" + ",".join(ids))
+
+    return isamAppliance.create_return_object()
 
 def modify(isamAppliance, id, comment, check_mode=False, force=False):
     """
@@ -123,29 +140,64 @@ def modify(isamAppliance, id, comment, check_mode=False, force=False):
     return isamAppliance.create_return_object()
 
 
-def apply(isamAppliance, id, check_mode=False, force=False):
+def apply(isamAppliance, id=None, comment=None, check_mode=False, force=False):
     """
     Apply a snapshot
+    There is a priority in the parameter to be used for snapshot applying: id > comment
     """
-    if force is True or _check(isamAppliance, id=id) is True:
-        if check_mode is True:
-            return isamAppliance.create_return_object(changed=True)
-        else:
-            return isamAppliance.invoke_post_snapshot_id("Applying snapshot", "/snapshots/apply/" + id,
-                                                         {"snapshot_id": id})
+    if comment != None and id == None:
+      ret_obj = search(isamAppliance, comment=comment)
+      if ret_obj['data'] == {}:
+        return isamAppliance.create_return_object(changed=False)
+      elif len(ret_obj['data']) == 1:
+        id = ret_obj['data'][0]
+      else:
+        logger.warn("There are multiple files with matching comments. Only one snapshot at a time can be applied !")
+
+    if id != None:
+      if force is True or _check(isamAppliance, id=id) is True:
+          if check_mode is True:
+              return isamAppliance.create_return_object(changed=True)
+          else:
+              return isamAppliance.invoke_post_snapshot_id("Applying snapshot", "/snapshots/apply/" + id,
+                                                          {"snapshot_id": id})
 
     return isamAppliance.create_return_object()
 
 
-def download(isamAppliance, filename, id, check_mode=False, force=False):
+def download(isamAppliance, filename, id=None, ids=[], comment=None, check_mode=False, force=False):
     """
     Download one snapshot file to a zip file.
-    TODO: Can hadnle multiple id's - but rest of logic deals with just one for now
+    Multiple file download is now supported.
+    For backwards compatibility the id parameter and old behaviour is checked at the beginning.
     """
-    if force is True or (_check(isamAppliance, id=id) is True and os.path.exists(filename) is False):
-        if check_mode is False:  # No point downloading a file if in check_mode
-            uri = "/snapshots/download?record_ids={0}".format(id)
-            return isamAppliance.invoke_get_file("Downloading snapshots", uri, filename)
+    if id != None:
+      if force is True or (_check(isamAppliance, id=id) is True and os.path.exists(filename) is False):
+          if check_mode is False:  # No point downloading a file if in check_mode
+              uri = "/snapshots/download?record_ids={0}".format(id)
+              return isamAppliance.invoke_get_file("Downloading snapshots", uri, filename)
+    else:
+      # Search for the id corresponding to the comment and consolidate them in the ids variable
+      if comment != None:
+        ret_obj = search(isamAppliance, comment=comment)
+        if ret_obj['data'] == {}:
+          logger.info("No snapshots found with text {0} in it.".format(comment))
+        else:
+          if ids == []:
+            ids = ret_obj['data']
+          else:
+            for snaps in ret_obj['data']:
+              ids.append(snaps)
+
+      # Additional check (REST-Calls) for every id in the ids variable is skipped as in this case error handling is better done by the REST API
+      if force is True or os.path.exists(filename) is False: # Don't overwrite if not forced to
+        if check_mode is True and ids != []: # We are in check_mode but would try to download named ids
+          return isamAppliance.create_return_object(changed=True)
+        elif check_mode is True and ids == []: # We are in check_mode but have nothing to download
+          return isamAppliance.create_return_object(changed=False)
+        else:
+          # Download all ids known so far
+          return isamAppliance.invoke_get_file("Downloading multiple snapshots","/snapshots/download?record_ids=" + ",".join(ids), filename )
 
     return isamAppliance.create_return_object()
 
@@ -177,6 +229,50 @@ def apply_latest(isamAppliance, check_mode=False, force=False):
 
     return apply(isamAppliance, id, check_mode, force)
 
+def upload(isamAppliance, file, comment=None, check_mode=False, force=False):
+    """
+    Upload Snapshot file
+    """
+    if force is True or _check_file(isamAppliance, file) is False:
+        if check_mode is True:
+            return isamAppliance.create_return_object(changed=True)
+        else:
+            if comment == None:
+              import zipfile
+
+              zFile = zipfile.ZipFile(file)
+              if "Comment" in zFile.namelist():
+                comment = zFile.open("Comment")
+
+            return isamAppliance.invoke_post_files(
+                "Upload Snapshot",
+                "/snapshots",
+                [{
+                    'file_formfield': 'uploadedfile',
+                    'filename': file,
+                    'mimetype': 'application/octet-stream'
+                }],
+                {
+                  'comment': comment if comment != None else ''
+                }, json_response=False)
+
+    return isamAppliance.create_return_object()
+
+def _check_file(isamAppliance, file):
+    """
+    Check if snapshot file already exists
+    """
+    import os.path
+
+    ret_obj = get(isamAppliance)
+
+    filename = os.path.basename(file)
+
+    for obj in ret_obj['data']:
+        if obj['filename'] == filename:
+            return True
+
+    return False
 
 def compare(isamAppliance1, isamAppliance2):
     """

--- a/ibmsecurity/isam/web/reverse_proxy/management_root/all.py
+++ b/ibmsecurity/isam/web/reverse_proxy/management_root/all.py
@@ -1,6 +1,8 @@
 import logging
 import ibmsecurity.utilities.tools
 import os.path
+from ibmsecurity.isam.web.reverse_proxy.management_root import directory
+from ibmsecurity.isam.web.reverse_proxy.management_root import file
 
 logger = logging.getLogger(__name__)
 
@@ -47,3 +49,22 @@ def import_zip(isamAppliance, instance_id, filename, check_mode=False, force=Fal
                 'type': 'file',
                 'force': force
             })
+            
+def check(isamAppliance, instance_id, id, name, type, check_mode=False, force=False):
+  ret_obj = None
+  
+  if(type.lower() == 'directory'):
+    ret_obj = directory._check(isamAppliance, instance_id, id, name)
+  elif(type.lower() == 'file'):
+    ret_obj = file._check(isamAppliance, instance_id, id, name)
+  else:
+    type = 'unknown'
+
+  data = {
+      'id': ret_obj,
+      'top': id,
+      'name': name,
+      'type': type
+  }
+    
+  return isamAppliance.create_return_object(data=data)

--- a/ibmsecurity/isam/web/reverse_proxy/management_root/file.py
+++ b/ibmsecurity/isam/web/reverse_proxy/management_root/file.py
@@ -239,7 +239,7 @@ def _check_import(isamAppliance, instance_id, id, filename, check_mode=False):
     """
     tmpdir = get_random_temp_dir()
     tmp_original_file = os.path.join(tmpdir, os.path.basename(id))
-    if _check(isamAppliance, instance_id, id, ''):
+    if (_check(isamAppliance, instance_id, id, '') is not None):
         export_file(isamAppliance, instance_id, id, tmp_original_file, check_mode=False, force=True)
         logger.debug("file already exists on appliance")
         if files_same(tmp_original_file, filename):

--- a/ibmsecurity/isam/web/reverse_proxy/oauth_configuration.py
+++ b/ibmsecurity/isam/web/reverse_proxy/oauth_configuration.py
@@ -15,7 +15,7 @@ def config(isamAppliance, instance_id, hostname='127.0.0.1', port=443, username=
 
     :param isamAppliance:
     :param instance_id:
-	:param junction:
+    :param junction:
     :param hostname:
     :param port:
     :param username:


### PR DESCRIPTION
Feature:

- sts module chains [idempotency]: idempotency: before comparison of server and client configuration properties with keyword 'password' are ignored (only for comparison) for self and partner configuration inside _check function
- sts module chains [search]: search for map rule reference ids (Introduction of new property "map.rule.reference.names" inside properties object. This property triggers search for map rule reference ids and adding this instead of the "map.rule.reference.names" property as ".map.rule.reference.ids" property. A prefix parameter for "map.rule.reference.names" is necessary to search properly for the mapping rule (therefore self-selected prefix should be considered for mapping rule creation)
- management_root [all.py]: check function to call file or directory check of corresponding sub classes. Includes some more return data than just the object id (id=object id, top=top level id[e.g. errors, management, junction_root], name=object name that was checked, type=object type [file, directory, unknown]
- runtime_template: adding _parse_id function for propper return of _check function
- cluster configuration: idempotency (To achiev idempotency for cluster configuration all parameter with word 'password' should be ignored for comparission of local and server configuration)

BugFix 
- cluster_configuration: if you want to configure remote hvdb the parameter hvdb_max_size is not necessary and therefore shouldn't be a default of '40'
- runtime_template: check function in directory and file class not properly checking if file exists for other function calls. Function parameters harmonization: get, _check, create, update, delete, rename, compare, export_file, import_file, _check_import for file and directory class
- management_root [file.py]: for _check_import function it was possible to have a object id of 1 leading to a false positive check that the file already existed on the server.

Typo: indent on oauth_configuration