### PR TITLE
AuthN Error

### DIFF
--- a/ibmsecurity/appliance/ibmappliance.py
+++ b/ibmsecurity/appliance/ibmappliance.py
@@ -6,6 +6,10 @@ class IBMError(Exception):
     def __init__(self, *args, **kwargs):
         Exception.__init__(self, *args, **kwargs)
 
+class IBMFatal(Exception):
+    def __init__(self, *args, **kwargs):
+        Exception.__init__(self, *args, **kwargs)
+
 class IBMResponse(dict):
     def __init__(self, *args, **kwargs):
         self.update(*args, **kwargs)

--- a/ibmsecurity/appliance/isamappliance.py
+++ b/ibmsecurity/appliance/isamappliance.py
@@ -43,7 +43,14 @@ class ISAMAppliance(IBMAppliance):
         return_obj['rc'] = http_response.status_code
 
         # Examine the response.
-        if (http_response.status_code != 200 and http_response.status_code != 204 and http_response.status_code != 201):
+        if (http_response.status_code == 403):
+            self.logger.error("  Request failed: ")
+            self.logger.error("     status code: {0}".format(http_response.status_code))
+            if http_response.text != "":
+                self.logger.error("     text: " + http_response.text)
+	    # Unconditionally raise exception to abort execution
+            raise IBMFatal("HTTP Return code: {0}".format(http_response.status_code), http_response.text)
+        elif (http_response.status_code != 200 and http_response.status_code != 204 and http_response.status_code != 201):
             self.logger.error("  Request failed: ")
             self.logger.error("     status code: {0}".format(http_response.status_code))
             if http_response.text != "":
@@ -51,13 +58,6 @@ class ISAMAppliance(IBMAppliance):
             if not ignore_error:
                 raise IBMError("HTTP Return code: {0}".format(http_response.status_code), http_response.text)
             return_obj['changed'] = False  # force changed to be False as there is an error
-        elif (http_response.status_code == 403):
-            self.logger.error("  Request failed: ")
-            self.logger.error("     status code: {0}".format(http_response.status_code))
-            if http_response.text != "":
-                self.logger.error("     text: " + http_response.text)
-	    # Unconditionally raise exception to abort execution
-            raise IBMFatal("HTTP Return code: {0}".format(http_response.status_code), http_response.text)
         else:
             return_obj['rc'] = 0
 

--- a/ibmsecurity/appliance/isamappliance.py
+++ b/ibmsecurity/appliance/isamappliance.py
@@ -4,6 +4,7 @@ from requests.packages.urllib3.exceptions import InsecureRequestWarning
 import logging
 from .ibmappliance import IBMAppliance
 from .ibmappliance import IBMError
+from .ibmappliance import IBMFatal
 from ibmsecurity.utilities import tools
 
 


### PR DESCRIPTION
This candidate implementation fix aims at correcting the scenario where an AuthN error (403) catched inside IBMSecurity did not immediately stop the current call. With this fix, whenever a Status code (403) is returned from the Appliance, the code will immediately stop its flow and throw back a new IBMFatal ‘exception’.  This is to correct situation where AuthN error would not get notice before and could even sometime lock account in remote user registry depending on the account locking policy.