### PR TITLE
Feature update: Add access policy parameter to API protection definition

### DIFF
--- a/ibmsecurity/isam/aac/api_protection/definitions.py
+++ b/ibmsecurity/isam/aac/api_protection/definitions.py
@@ -1,5 +1,6 @@
 import logging
 from ibmsecurity.utilities import tools
+from ibmsecurity.isam.aac import access_policy
 
 logger = logging.getLogger(__name__)
 
@@ -57,7 +58,7 @@ def search(isamAppliance, name, check_mode=False, force=False):
     return return_obj
 
 
-def add(isamAppliance, name, description="", grantTypes=["AUTHORIZATION_CODE"], tcmBehavior="NEVER_PROMPT",
+def add(isamAppliance, name, description="", accessPolicyName=None, grantTypes=["AUTHORIZATION_CODE"], tcmBehavior="NEVER_PROMPT",
         accessTokenLifetime=3600, accessTokenLength=20, enforceSingleUseAuthorizationGrant=False,
         authorizationCodeLifetime=300, authorizationCodeLength=30, issueRefreshToken=True, refreshTokenLength=40,
         maxAuthorizationGrantLifetime=604800, enforceSingleAccessTokenPerGrant=False,
@@ -97,6 +98,22 @@ def add(isamAppliance, name, description="", grantTypes=["AUTHORIZATION_CODE"], 
                 "pinLength": pinLength,
                 "tokenCharSet": tokenCharSet
             }
+            if accessPolicyName is not None:
+                if tools.version_compare(isamAppliance.facts["version"], "9.0.4.0") < 0:
+                    warnings.append(
+                        "Appliance at version: {0}, access policy: {1} is not supported. Needs 9.0.4.0 or higher. Ignoring access policy for this call.".format(
+                            isamAppliance.facts["version"], oidc))
+                    accessPolicyName = None
+                else:
+                    ret_obj = access_policy.search(isamAppliance, accessPolicyName, check_mode=check_mode, force=force)
+                    if ret_obj['data'] == {}:
+                        warnings = ret_obj["warnings"]
+                        warnings.append(
+                            "Access Policy {0} is not found. Cannot add definition.".format(accessPolicyName))
+                        return isamAppliance.create_return_object(warnings=warnings)
+                    else:
+                        json_data["accessPolicyId"] = int(ret_obj['data'])
+
             if oidc is not None:
                 if tools.version_compare(isamAppliance.facts["version"], "9.0.4.0") < 0:
                     warnings.append(
@@ -146,7 +163,7 @@ def delete(isamAppliance, name, check_mode=False, force=False):
     return isamAppliance.create_return_object(warnings=warnings)
 
 
-def update(isamAppliance, name, description="", grantTypes=["AUTHORIZATION_CODE"], tcmBehavior="NEVER_PROMPT",
+def update(isamAppliance, name, description="", accessPolicyName=None, grantTypes=["AUTHORIZATION_CODE"], tcmBehavior="NEVER_PROMPT",
            accessTokenLifetime=3600, accessTokenLength=20, enforceSingleUseAuthorizationGrant=False,
            authorizationCodeLifetime=300, authorizationCodeLength=30, issueRefreshToken=True, refreshTokenLength=40,
            maxAuthorizationGrantLifetime=604800, enforceSingleAccessTokenPerGrant=False,
@@ -185,6 +202,22 @@ def update(isamAppliance, name, description="", grantTypes=["AUTHORIZATION_CODE"
         "pinLength": pinLength,
         "tokenCharSet": tokenCharSet
     }
+    if accessPolicyName is not None:
+        if tools.version_compare(isamAppliance.facts["version"], "9.0.4.0") < 0:
+            warnings.append(
+                "Appliance at version: {0}, access policy: {1} is not supported. Needs 9.0.4.0 or higher. Ignoring access policy for this call.".format(
+                    isamAppliance.facts["version"], oidc))
+            accessPolicyName = None
+        else:
+            ret_obj = access_policy.search(isamAppliance, accessPolicyName, check_mode=check_mode, force=force)
+            if ret_obj['data'] == {}:
+                warnings = ret_obj["warnings"]
+                warnings.append(
+                    "Access Policy {0} is not found. Cannot update definition.".format(accessPolicyName))
+                return isamAppliance.create_return_object(warnings=warnings)
+            else:
+                json_data["accessPolicyId"] = int(ret_obj['data'])
+
     if oidc is not None:
         if tools.version_compare(isamAppliance.facts["version"], "9.0.4.0") < 0:
             warnings.append(
@@ -280,7 +313,7 @@ def update(isamAppliance, name, description="", grantTypes=["AUTHORIZATION_CODE"
     return isamAppliance.create_return_object(warnings=warnings)
 
 
-def set(isamAppliance, name, description="", grantTypes=["AUTHORIZATION_CODE"], tcmBehavior="NEVER_PROMPT",
+def set(isamAppliance, name, description="", accessPolicyName=None, grantTypes=["AUTHORIZATION_CODE"], tcmBehavior="NEVER_PROMPT",
         accessTokenLifetime=3600, accessTokenLength=20, enforceSingleUseAuthorizationGrant=False,
         authorizationCodeLifetime=300, authorizationCodeLength=30, issueRefreshToken=True, refreshTokenLength=40,
         maxAuthorizationGrantLifetime=604800, enforceSingleAccessTokenPerGrant=False,
@@ -293,8 +326,8 @@ def set(isamAppliance, name, description="", grantTypes=["AUTHORIZATION_CODE"], 
     if (search(isamAppliance, name=name))['data'] == {}:
         # Force the add - we already know policy does not exist
         logger.info("Definition {0} had no match, requesting to add new one.".format(name))
-        return add(isamAppliance=isamAppliance, name=name, description=description, grantTypes=grantTypes,
-                   tcmBehavior=tcmBehavior,
+        return add(isamAppliance=isamAppliance, name=name, description=description, accessPolicyName=accessPolicyName, 
+                   grantTypes=grantTypes, tcmBehavior=tcmBehavior,
                    accessTokenLifetime=accessTokenLifetime, accessTokenLength=accessTokenLength,
                    enforceSingleUseAuthorizationGrant=enforceSingleUseAuthorizationGrant,
                    authorizationCodeLifetime=authorizationCodeLifetime, authorizationCodeLength=authorizationCodeLength,
@@ -307,8 +340,8 @@ def set(isamAppliance, name, description="", grantTypes=["AUTHORIZATION_CODE"], 
     else:
         # Update request
         logger.info("Definition {0} exists, requesting to update.".format(name))
-        return update(isamAppliance=isamAppliance, name=name, description=description, grantTypes=grantTypes,
-                      tcmBehavior=tcmBehavior,
+        return update(isamAppliance=isamAppliance, name=name, description=description, accessPolicyName=accessPolicyName, 
+                      grantTypes=grantTypes, tcmBehavior=tcmBehavior,
                       accessTokenLifetime=accessTokenLifetime, accessTokenLength=accessTokenLength,
                       enforceSingleUseAuthorizationGrant=enforceSingleUseAuthorizationGrant,
                       authorizationCodeLifetime=authorizationCodeLifetime,


### PR DESCRIPTION
Newer versions (9.0.4->) have access policy as part of the API protection definition endpoint. I added the new parameter. It should work as previously when the parameter is not provided. I followed the same conventions for version checks as was in place for other parameters.