### PR TITLE
several changes for server_connections (BugFixes) +1 search feature in authentication mechanisms 

### DIFF
--- a/ibmsecurity/isam/aac/authentication/mechanisms.py
+++ b/ibmsecurity/isam/aac/authentication/mechanisms.py
@@ -1,6 +1,9 @@
 import logging
 from ibmsecurity.utilities import tools
 from ibmsecurity.isam.aac.authentication import mechanism_types
+from ibmsecurity.isam.aac.server_connections import smtp
+from ibmsecurity.isam.aac.server_connections import ci
+from ibmsecurity.isam.aac.server_connections import ws
 
 logger = logging.getLogger(__name__)
 
@@ -99,6 +102,20 @@ def add(isamAppliance, name, uri, description="", attributes=None, properties=No
             if attributes is not None:
                 json_data['attributes'] = attributes
             if properties is not None:
+                logger.info("Searching for keys to substitute value with uuids")
+                id = {}
+                for property in properties:
+                    if property['key'] == "EmailMessage.serverConnection":
+                        id = smtp.search(isamAppliance, property['value'])['data']
+                        logger.info("Found EmailMessage.serverConnection by name[{}] with uuid[{}]".format(property['value'], id))
+                    elif property['key'] == "ScimConfig.serverConnection":
+                        id = ws.search(isamAppliance, property['value'])['data']
+                        logger.info("Found ScimConfig.serverConnection by name[{}] with uuid[{}]".format(property['value'], id))
+                    elif property['key'] == "CI.serverConnection":
+                        id = ci.search(isamAppliance, property['value'])['data']
+                        logger.info("Found CI.serverConnection by name[{}] with uuid[{}]".format(property['value'], id))
+                    if id != {}:
+                        property['value'] = id
                 json_data['properties'] = properties
             return isamAppliance.invoke_post(
                 "Create a new federation", module_uri, json_data,
@@ -197,6 +214,20 @@ def _check(isamAppliance, name, description, attributes, properties, predefined,
             except:
                 pass
         if properties is not None:
+            logger.info("Searching for keys to substitute value with uuids")
+            id = {}
+            for property in properties:
+                if property['key'] == "EmailMessage.serverConnection":
+                    id = smtp.search(isamAppliance, property['value'])['data']
+                    logger.info("Found EmailMessage.serverConnection by name[{}] with uuid[{}]".format(property['value'], id))
+                elif property['key'] == "ScimConfig.serverConnection":
+                    id = ws.search(isamAppliance, property['value'])['data']
+                    logger.info("Found ScimConfig.serverConnection by name[{}] with uuid[{}]".format(property['value'], id))
+                elif property['key'] == "CI.serverConnection":
+                    id = ci.search(isamAppliance, property['value'])['data']
+                    logger.info("Found CI.serverConnection by name[{}] with uuid[{}]".format(property['value'], id))
+                if id != {}:
+                    property['value'] = id
             json_data['properties'] = properties
         else:
             # May not exist so skip any exceptions when deleting

--- a/ibmsecurity/isam/aac/server_connections/ci.py
+++ b/ibmsecurity/isam/aac/server_connections/ci.py
@@ -1,9 +1,9 @@
 import logging
-import ibmsecurity.utilities.tools
+from ibmsecurity.utilities import tools
 
 logger = logging.getLogger(__name__)
 
-requires_modules = ["mga"]
+requires_modules = ["mga", "federation"]
 requires_version = "9.0.5.0"
 
 
@@ -37,12 +37,10 @@ def set(isamAppliance, name, connection, description='', locked=False, new_name=
     """
     if _check_exists(isamAppliance, name=name) is False:
         # Force the add - we already know connection does not exist
-        return add(isamAppliance=isamAppliance, name=name, connection=connection, description=description,
-                   locked=locked, check_mode=check_mode, force=True)
+        return add(isamAppliance=isamAppliance, name=name, connection=connection, description=description, locked=locked, check_mode=check_mode, force=True)
     else:
         # Update request
-        return update(isamAppliance=isamAppliance, name=name, connection=connection, description=description,
-                      locked=locked, new_name=new_name, check_mode=check_mode, force=force)
+        return update(isamAppliance=isamAppliance, name=name, connection=connection, description=description, locked=locked, new_name=new_name, check_mode=check_mode, force=force)
 
 
 def add(isamAppliance, name, connection, description='', locked=False, check_mode=False, force=False):
@@ -62,17 +60,18 @@ def add(isamAppliance, name, connection, description='', locked=False, check_mod
 
     return isamAppliance.create_return_object()
 
-
-def delete(isamAppliance, name, check_mode=False, force=False):
+def delete(isamAppliance, name=None, id=None, check_mode=False, force=False):
     """
     Deleting a CI server connection
     """
-    if force is True or _check_exists(isamAppliance, name=name) is True:
+    if force is True or _check_exists(isamAppliance, name=name, id=id) is True:
         if check_mode is True:
             return isamAppliance.create_return_object(changed=True)
         else:
-            ret_obj = search(isamAppliance, name=name)
-            id = ret_obj['data']
+            if id is None:
+                ret_obj = search(isamAppliance, name=name)
+                id = ret_obj['data']
+
             return isamAppliance.invoke_delete(
                 "Deleting a CI server connection",
                 "/mga/server_connections/ci/{0}/v1".format(id), requires_modules=requires_modules,
@@ -84,25 +83,48 @@ def delete(isamAppliance, name, check_mode=False, force=False):
 def update(isamAppliance, name, connection, description='', locked=False, new_name=None, check_mode=False, force=False):
     """
     Modifying a CI server connection
-    Use new_name to rename the connection, cannot compare password so update will take place everytime
+    Use new_name to rename the connection.
     """
+    ret_obj = get(isamAppliance, name)
+    warnings = ret_obj["warnings"]
 
-    if force is True or _check_exists(isamAppliance, name):
+    if ret_obj["data"] == {}:
+        warnings.append("CI Service connection {0} not found, skipping update.".format(name))
+        return isamAppliance.create_return_object(warnings=warnings)
+    else:
+        id = ret_obj["data"]["uuid"]
+
+    needs_update = False
+
+    json_data = _create_json(name=name, description=description, locked=locked, connection=connection)
+    if new_name is not None:  # Rename condition
+        json_data['name'] = new_name
+
+    if force is not True:
+        if 'uuid' in ret_obj['data']:
+            del ret_obj['data']['uuid']
+        if 'clientSecret' in connection:
+            warnings.append("Since existing clientSecret cannot be read for ci connections - this parameter will be ignored for idempotency. Add 'force' parameter to update the connection with a new clientSecret.")
+            connection.pop('clientSecret', None)
+
+        sorted_ret_obj = tools.json_sort(ret_obj['data'])
+        sorted_json_data = tools.json_sort(json_data)
+        logger.debug("Sorted Existing Data:{0}".format(sorted_ret_obj))
+        logger.debug("Sorted Desired  Data:{0}".format(sorted_json_data))
+
+        if sorted_ret_obj != sorted_json_data:
+            needs_update = True
+
+    if force is True or needs_update is True:
         if check_mode is True:
-            return isamAppliance.create_return_object(changed=True)
+            return isamAppliance.create_return_object(changed=True, warnings=warnings)
         else:
-            json_data = _create_json(name=name, description=description, locked=locked, connection=connection)
-            if new_name is not None:  # Rename condition
-                json_data['name'] = new_name
-            ret_obj = search(isamAppliance, name=name)
-            id = ret_obj['data']
             return isamAppliance.invoke_put(
                 "Modifying a CI server connection",
                 "/mga/server_connections/ci/{0}/v1".format(id), json_data, requires_modules=requires_modules,
                 requires_version=requires_version)
 
-    return isamAppliance.create_return_object()
-
+    return isamAppliance.create_return_object(warnings=warnings)
 
 def _create_json(name, description, locked, connection):
     """

--- a/ibmsecurity/isam/aac/server_connections/jdbc.py
+++ b/ibmsecurity/isam/aac/server_connections/jdbc.py
@@ -1,7 +1,9 @@
 import logging
-import ibmsecurity.utilities.tools
+from ibmsecurity.utilities import tools
 
 logger = logging.getLogger(__name__)
+requires_modules = ["mga", "federation"]
+requires_version = "9.0.2.1"  # Will change if introduced in an earlier version.
 
 
 def get_all(isamAppliance, check_mode=False, force=False):
@@ -26,24 +28,20 @@ def get(isamAppliance, name, check_mode=False, force=False):
                                         "/mga/server_connections/jdbc/{0}/v1".format(id))
 
 
-def set(isamAppliance, name, connection, type, jndiId, description='', locked=False, connectionManager=None,
+def set(isamAppliance, name, connection, jndiId, description='', locked=False, connectionManager=None,
         new_name=None, check_mode=False, force=False):
     """
     Creating or Modifying an JDBC server connection
     """
     if _check_exists(isamAppliance, name=name) is False:
         # Force the add - we already know connection does not exist
-        return add(isamAppliance, name=name, connection=connection, type=type, jndiId=jndiId, description=description,
-                   locked=locked, connectionManager=connectionManager, check_mode=check_mode,
-                   force=True)
+        return add(isamAppliance=isamAppliance, name=name, connection=connection, jndiId=jndiId, description=description, locked=locked, connectionManager=connectionManager, check_mode=check_mode, force=True)
     else:
         # Update request
-        return update(isamAppliance=isamAppliance, name=name, connection=connection, type=type, jndiId=jndiId,
-                      description=description, locked=locked, connectionManager=connectionManager, new_name=new_name,
-                      check_mode=check_mode, force=force)
+        return update(isamAppliance=isamAppliance, name=name, connection=connection, jndiId=jndiId, description=description, locked=locked, connectionManager=connectionManager, new_name=new_name, check_mode=check_mode, force=force)
 
 
-def add(isamAppliance, name, connection, type, jndiId, description='', locked=False, connectionManager=None,
+def add(isamAppliance, name, connection, jndiId, description='', locked=False, connectionManager=None,
         check_mode=False, force=False):
     """
     Creating a JDBC server connection
@@ -55,7 +53,7 @@ def add(isamAppliance, name, connection, type, jndiId, description='', locked=Fa
             return isamAppliance.invoke_post(
                 "Creating a JDBC server connection",
                 "/mga/server_connections/jdbc/v1",
-                _create_json(name=name, description=description, locked=locked, type=type, connection=connection,
+                _create_json(name=name, description=description, locked=locked, connection=connection,
                              connectionManager=connectionManager, jndiId=jndiId))
 
     return isamAppliance.create_return_object()
@@ -78,39 +76,62 @@ def delete(isamAppliance, name, check_mode=False, force=False):
     return isamAppliance.create_return_object()
 
 
-def update(isamAppliance, name, connection, type, jndiId, description='', locked=False, connectionManager=None,
+def update(isamAppliance, name, connection, jndiId, description='', locked=False, connectionManager=None,
            new_name=None, check_mode=False, force=False):
     """
     Modifying a JDBC server connection
 
-    Use new_name to rename the connection, cannot compare password so update will take place everytime
+    Use new_name to rename the connection.
     """
+    ret_obj = get(isamAppliance, name)
+    warnings = ret_obj["warnings"]
 
-    if force is True or _check_exists(isamAppliance, name):
+    if ret_obj["data"] == {}:
+        warnings.append("JDBC Service connection {0} not found, skipping update.".format(name))
+        return isamAppliance.create_return_object(warnings=warnings)
+    else:
+        id = ret_obj["data"]["uuid"]
+
+    needs_update = False
+
+    json_data = _create_json(name=name, description=description, locked=locked, connection=connection, connectionManager=connectionManager, jndiId=jndiId)
+    if new_name is not None:  # Rename condition
+        json_data['name'] = new_name
+
+    if force is not True:
+        if 'uuid' in ret_obj['data']:
+            del ret_obj['data']['uuid']
+        if 'password' in connection:
+            warnings.append("Since existing password cannot be read for jdbc connections - this parameter will be ignored for idempotency. Add 'force' parameter to update the connection with a new password.")
+            connection.pop('password', None)
+
+        sorted_ret_obj = tools.json_sort(ret_obj['data'])
+        sorted_json_data = tools.json_sort(json_data)
+        logger.debug("Sorted Existing Data:{0}".format(sorted_ret_obj))
+        logger.debug("Sorted Desired  Data:{0}".format(sorted_json_data))
+
+        if sorted_ret_obj != sorted_json_data:
+            needs_update = True
+
+    if force is True or needs_update is True:
         if check_mode is True:
-            return isamAppliance.create_return_object(changed=True)
+            return isamAppliance.create_return_object(changed=True, warnings=warnings)
         else:
-            json_data = _create_json(name=name, description=description, locked=locked, type=type,
-                                     connection=connection, connectionManager=connectionManager, jndiId=jndiId)
-            ret_obj = search(isamAppliance, name)
-            id = ret_obj['data']
+            return isamAppliance.invoke_put(
+                "Modifying a JDBC server connection",
+                "/mga/server_connections/jdbc/{0}/v1".format(id), json_data, requires_modules=requires_modules,
+                requires_version=requires_version, warnings=warnings)
 
-            if new_name is not None:  # Rename condition
-                json_data['name'] = new_name
-
-            return isamAppliance.invoke_put("Modifying a JDBC server connection",
-                                            "/mga/server_connections/jdbc/{0}/v1".format(id), json_data)
-
-    return isamAppliance.create_return_object()
+    return isamAppliance.create_return_object(warnings=warnings)
 
 
-def _create_json(name, description, locked, type, jndiId, connection, connectionManager):
+def _create_json(name, description, locked, jndiId, connection, connectionManager):
     """
     Create a JSON to be used for the REST API call
     """
     json = {
         "connection": connection,
-        "type": type,
+        "type": "db2",
         "jndiId": jndiId,
         "name": name,
         "description": description,

--- a/ibmsecurity/isam/aac/server_connections/ldap.py
+++ b/ibmsecurity/isam/aac/server_connections/ldap.py
@@ -1,7 +1,9 @@
 import logging
-import ibmsecurity.utilities.tools
+from ibmsecurity.utilities import tools
 
 logger = logging.getLogger(__name__)
+requires_modules = ["mga", "federation"]
+requires_version = "9.0.2.1"  # Will change if introduced in an earlier version.
 
 
 def get_all(isamAppliance, check_mode=False, force=False):
@@ -33,14 +35,10 @@ def set(isamAppliance, name, connection, description='', locked=False, connectio
     """
     if _check_exists(isamAppliance, name=name) is False:
         # Force the add - we already know connection does not exist
-        return add(isamAppliance=isamAppliance, name=name, connection=connection, description=description,
-                   locked=locked, connectionManager=connectionManager, servers=servers, check_mode=check_mode,
-                   force=True)
+        return add(isamAppliance=isamAppliance, name=name, connection=connection, description=description, locked=locked, connectionManager=connectionManager, servers=servers, check_mode=check_mode, force=True)
     else:
         # Update request
-        return update(isamAppliance=isamAppliance, name=name, connection=connection, description=description,
-                      locked=locked, connectionManager=connectionManager, servers=servers, new_name=new_name,
-                      check_mode=check_mode, force=force)
+        return update(isamAppliance=isamAppliance, name=name, connection=connection, description=description, locked=locked, connectionManager=connectionManager, servers=servers, new_name=new_name, check_mode=check_mode, force=force)
 
 
 def add(isamAppliance, name, connection, description='', locked=False, connectionManager=None, servers=None,
@@ -83,26 +81,49 @@ def update(isamAppliance, name, connection, description='', locked=False, connec
     """
     Modifying an LDAP server connection
 
-    Use new_name to rename the connection, cannot compare password so update will take place everytime
+    Use new_name to rename the connection.
     """
-    if force is True or _check_exists(isamAppliance, name=name) is True:
+
+    ret_obj = get(isamAppliance, name)
+    warnings = ret_obj["warnings"]
+
+    if ret_obj["data"] == {}:
+        warnings.append("LDAP Service connection {0} not found, skipping update.".format(name))
+        return isamAppliance.create_return_object(warnings=warnings)
+    else:
+        id = ret_obj["data"]["uuid"]
+
+    needs_update = False
+
+    json_data = _create_json(name=name, description=description, locked=locked, servers=servers, connection=connection, connectionManager=connectionManager)
+    if new_name is not None:  # Rename condition
+        json_data['name'] = new_name
+
+    if force is not True:
+        if 'uuid' in ret_obj['data']:
+            del ret_obj['data']['uuid']
+        if 'bindPwd' in connection:
+            warnings.append("Since existing bindPwd cannot be read for ldap connections - this parameter will be ignored for idempotency. Add 'force' parameter to update the connection with a new bindPwd.")
+            connection.pop('bindPwd', None)
+
+        sorted_ret_obj = tools.json_sort(ret_obj['data'])
+        sorted_json_data = tools.json_sort(json_data)
+        logger.debug("Sorted Existing Data:{0}".format(sorted_ret_obj))
+        logger.debug("Sorted Desired  Data:{0}".format(sorted_json_data))
+
+        if sorted_ret_obj != sorted_json_data:
+            needs_update = True
+
+    if force is True or needs_update is True:
         if check_mode is True:
-            return isamAppliance.create_return_object(changed=True)
+            return isamAppliance.create_return_object(changed=True, warnings=warnings)
         else:
-            json_data = _create_json(name=name, description=description, locked=locked, servers=servers,
-                                     connection=connection, connectionManager=connectionManager)
-            if new_name is not None:  # Rename condition
-                json_data['name'] = new_name
-
-            ret_obj = search(isamAppliance, name=name)
-            id = ret_obj['data']
-
             return isamAppliance.invoke_put(
                 "Modifying an LDAP server connection",
-                "/mga/server_connections/ldap/{0}/v1".format(id), json_data)
+                "/mga/server_connections/ldap/{0}/v1".format(id), json_data, requires_modules=requires_modules,
+                requires_version=requires_version, warnings=warnings)
 
-    return isamAppliance.create_return_object()
-
+    return isamAppliance.create_return_object(warnings=warnings)
 
 def _create_json(name, description, locked, servers, connection, connectionManager):
     """

--- a/ibmsecurity/isam/aac/server_connections/smtp.py
+++ b/ibmsecurity/isam/aac/server_connections/smtp.py
@@ -1,7 +1,9 @@
 import logging
-import ibmsecurity.utilities.tools
+from ibmsecurity.utilities import tools
 
 logger = logging.getLogger(__name__)
+requires_modules = ["mga", "federation"]
+requires_version = "9.0.2.1"  # Will change if introduced in an earlier version.
 
 
 def get_all(isamAppliance, check_mode=False, force=False):
@@ -26,20 +28,16 @@ def get(isamAppliance, name, check_mode=False, force=False):
                                         "/mga/server_connections/smtp/{0}/v1".format(id))
 
 
-def set(isamAppliance, name, connection, description='', locked=False, connectionManager=None, new_name=None,
-        check_mode=False, force=False):
+def set(isamAppliance, name, connection, description='', locked=False, connectionManager=None, new_name=None, check_mode=False, force=False):
     """
     Creating or Modifying an SMTP server connection
     """
     if _check_exists(isamAppliance, name=name) is False:
         # Force the add - we already know connection does not exist
-        return add(isamAppliance=isamAppliance, name=name, connection=connection, description=description,
-                   locked=locked, connectionManager=connectionManager, check_mode=check_mode, force=True)
+        return add(isamAppliance=isamAppliance, name=name, connection=connection, description=description, locked=locked, connectionManager=connectionManager, check_mode=check_mode, force=True)
     else:
         # Update request
-        return update(isamAppliance=isamAppliance, name=name, connection=connection, description=description,
-                      locked=locked, connectionManager=connectionManager, new_name=new_name,
-                      check_mode=check_mode, force=force)
+        return update(isamAppliance=isamAppliance, name=name, connection=connection, description=description, locked=locked, connectionManager=connectionManager, new_name=new_name, check_mode=check_mode, force=force)
 
 
 def add(isamAppliance, name, connection, description='', locked=False, connectionManager=None, check_mode=False,
@@ -82,26 +80,48 @@ def update(isamAppliance, name, connection, description='', locked=False, connec
     """
     Modifying a SMTP server connection
 
-    Use new_name to rename the connection, cannot compare password so update will take place everytime
+    Use new_name to rename the connection.
     """
+    ret_obj = get(isamAppliance, name)
+    warnings = ret_obj["warnings"]
 
-    if force is True or _check_exists(isamAppliance, name):
+    if ret_obj["data"] == {}:
+        warnings.append("SMTP Service connection {0} not found, skipping update.".format(name))
+        return isamAppliance.create_return_object(warnings=warnings)
+    else:
+        id = ret_obj["data"]["uuid"]
+
+    needs_update = False
+
+    json_data = _create_json(name=name, description=description, locked=locked, connection=connection, connectionManager=connectionManager)
+    if new_name is not None:  # Rename condition
+        json_data['name'] = new_name
+
+    if force is not True:
+        if 'uuid' in ret_obj['data']:
+            del ret_obj['data']['uuid']
+        if 'password' in connection:
+            warnings.append("Since existing password cannot be read for smtp connections - this parameter will be ignored for idempotency. Add 'force' parameter to update the connection with a new password.")
+            connection.pop('password', None)
+
+        sorted_ret_obj = tools.json_sort(ret_obj['data'])
+        sorted_json_data = tools.json_sort(json_data)
+        logger.debug("Sorted Existing Data:{0}".format(sorted_ret_obj))
+        logger.debug("Sorted Desired  Data:{0}".format(sorted_json_data))
+
+        if sorted_ret_obj != sorted_json_data:
+            needs_update = True
+
+    if force is True or needs_update is True:
         if check_mode is True:
-            return isamAppliance.create_return_object(changed=True)
+            return isamAppliance.create_return_object(changed=True, warnings=warnings)
         else:
-            json_data = _create_json(name=name, description=description, locked=locked, connection=connection,
-                                     connectionManager=connectionManager)
-            if new_name is not None:  # Rename condition
-                json_data['name'] = new_name
-
-            ret_obj = search(isamAppliance, name=name)
-            id = ret_obj['data']
-
             return isamAppliance.invoke_put(
                 "Modifying a SMTP server connection",
-                "/mga/server_connections/smtp/{0}/v1".format(id), json_data)
+                "/mga/server_connections/smtp/{0}/v1".format(id), json_data, requires_modules=requires_modules,
+                requires_version=requires_version, warnings=warnings)
 
-    return isamAppliance.create_return_object()
+    return isamAppliance.create_return_object(warnings=warnings)
 
 
 def _create_json(name, description, locked, connection, connectionManager):

--- a/ibmsecurity/isam/aac/server_connections/ws.py
+++ b/ibmsecurity/isam/aac/server_connections/ws.py
@@ -1,5 +1,5 @@
 import logging
-import ibmsecurity.utilities.tools
+from ibmsecurity.utilities import tools
 
 logger = logging.getLogger(__name__)
 
@@ -95,10 +95,40 @@ def update(isamAppliance, name, connection, description='', locked=False, new_na
 
     Use new_name to rename the connection, cannot compare password so update will take place everytime
     """
+    ret_obj = get(isamAppliance, name)
+    warnings = ret_obj["warnings"]
 
-    if force is True or _check_exists(isamAppliance, name):
+    if ret_obj["data"] == {}:
+        warnings.append("Web Service connection {0} not found, skipping update.".format(name))
+        return isamAppliance.create_return_object(warnings=warnings)
+    else:
+        id = ret_obj["data"]["uuid"]
+
+    needs_update = False
+
+    json_data = _create_json(name=name, description=description, locked=locked, connection=connection)
+    if new_name is not None:  # Rename condition
+        json_data['name'] = new_name
+
+    if force is not True:
+        if 'uuid' in ret_obj['data']:
+            del ret_obj['data']['uuid']
+
+        if 'password' in connection:
+            warnings.append("Since existing password cannot be read for ws connections - this parameter will be ignored for idempotency. Add 'force' parameter to update the connection with a new password.")
+            connection.pop('password', None)
+
+        sorted_ret_obj = tools.json_sort(ret_obj['data'])
+        sorted_json_data = tools.json_sort(json_data)
+        logger.debug("Sorted Existing Data:{0}".format(sorted_ret_obj))
+        logger.debug("Sorted Desired  Data:{0}".format(sorted_json_data))
+
+        if sorted_ret_obj != sorted_json_data:
+            needs_update = True
+
+    if force is True or needs_update is True:
         if check_mode is True:
-            return isamAppliance.create_return_object(changed=True)
+            return isamAppliance.create_return_object(changed=True, warnings=warnings)
         else:
             json_data = _create_json(name=name, description=description, locked=locked, connection=connection)
             if new_name is not None:  # Rename condition
@@ -120,12 +150,10 @@ def set(isamAppliance, name, connection, description='', locked=False, new_name=
     """
     if (search(isamAppliance, name=name))['data'] == {}:
         # Force the add - we already know connection does not exist
-        return add(isamAppliance=isamAppliance, name=name, connection=connection, description=description,
-                   locked=locked, check_mode=check_mode, force=True)
+        return add(isamAppliance=isamAppliance, name=name, connection=connection, description=description, locked=locked, check_mode=check_mode, force=True)
     else:
         # Update request
-        return update(isamAppliance=isamAppliance, name=name, connection=connection, description=description,
-                      locked=locked, new_name=new_name, check_mode=check_mode, force=force)
+        return update(isamAppliance=isamAppliance, name=name, connection=connection, description=description, locked=locked, new_name=new_name, check_mode=check_mode, force=force)
 
 
 def _create_json(name, description, locked, connection):


### PR DESCRIPTION
- BugFix: server_connections missing id parameter (ci.py, jdbc.py, ldap.py,smtp.py)
- BugFix: server_connections missing federation as requires_modules and/or requires_version parameter (ci.py, jdbc.py, ldap.py,smtp.py)
- Remove unecessary parameter type as this is a static string for every class (ci.py, jdbc.py, ldap.py, smtp.py):
    - ws.py [type=ws]
    - ldap.py [type=ldap]
    - ci.py [type=ci]
    - smtp.py [type=smtp]
    - jdbc.py [type=db2]
  Unfortunately the type for jdbc is db2 and therefore different to the filename. I used the filename in previous implementations as type parameter for some playbooks, which now would break by introducing the additional type parameter.
- Feature (authentication\mechanisms.py): set EmailMessage, ScimConfig, CI server connections properties by name: This feature attempts to find the uuids from the properties "EmailMessage.serverConnection", "ScimConfig.serverConnection" and "CI.serverConnection". If a UUID is found, the value for this property is replaced by this UUID, otherwise the value remains unchanged.
This allows to set ServerConnections by name, while still allowing you to create the ServerConnection directly from the UUID.