### PR TITLE
BugFixes+Features: aac\runtime_templates, reverse_proxy\management_root

### DIFF
--- a/ibmsecurity/isam/aac/runtime_template/directory.py
+++ b/ibmsecurity/isam/aac/runtime_template/directory.py
@@ -97,6 +97,40 @@ def create(isamAppliance, path, name, check_mode=False, force=False):
 
     return isamAppliance.create_return_object(warnings=warnings)
 
+def create(isamAppliance, id, check_mode=False, force=False):
+    """
+    Creating a directory in the runtime template files directory
+
+    :param isamAppliance:
+    :param id:
+    :param name:
+    :param check_mode:
+    :param force:
+    :return:
+    """
+    warnings = []
+    
+    path = os.path.dirname(id)
+    name = os.path.basename(id)
+    
+    check_dir = _check(isamAppliance, id)
+    if check_dir != None:
+        warnings.append("Directory {0} exists. Ignoring create.".format(id))
+
+    if force is True or check_dir == None:
+        if check_mode is True:          
+            return isamAppliance.create_return_object(changed=True, warnings=warnings)
+        else:
+            return isamAppliance.invoke_post(
+                "Creating a directory in the runtime template files directory",
+                "/mga/template_files/{0}".format(path),
+                {
+                    'dir_name': name,
+                    'type': 'dir'
+                })
+
+    return isamAppliance.create_return_object(warnings=warnings)
+
 
 def delete(isamAppliance, id, check_mode=False, force=False):
     """

--- a/ibmsecurity/isam/aac/runtime_template/root.py
+++ b/ibmsecurity/isam/aac/runtime_template/root.py
@@ -1,8 +1,13 @@
 import logging
 import os.path
+import ibmsecurity.utilities.tools
+import zipfile
+import difflib
+import hashlib
+import shutil
 from ibmsecurity.isam.aac.runtime_template import directory
 from ibmsecurity.isam.aac.runtime_template import file
-
+from ibmsecurity.utilities.tools import get_random_temp_dir, files_same_zip_content
 logger = logging.getLogger(__name__)
 
 uri = "/mga/template_files"
@@ -28,41 +33,107 @@ def export_file(isamAppliance, filename, check_mode=False, force=False):
     return isamAppliance.create_return_object()
 
 
-def import_file(isamAppliance, filename, check_mode=False, force=False):
+def import_file(isamAppliance, filename, delete_missing=False, check_mode=False, force=False):
     """
-    Replace all Runtime Template Files
+    Import all Runtime Template Files
     """
-    if check_mode is True:
-        return isamAppliance.create_return_object(changed=True)
-    else:
-        return isamAppliance.invoke_post_files(
-            "Replace all Runtime Template Files",
-            uri,
-            [
+    warnings = []
+
+    if force is True or _check_import(isamAppliance, filename):
+        if delete_missing is True:
+            tempdir = get_random_temp_dir()
+            tempfilename = "template_files.zip"
+            tempfile =  os.path.join(tempdir, tempfilename)
+            export_file(isamAppliance, tempfile)
+
+            zServerFile = zipfile.ZipFile(tempfile)
+            zClientFile = zipfile.ZipFile(filename)
+
+            files_on_server = [];
+            for info in zServerFile.infolist():
+                files_on_server.append(info.filename)
+            files_on_client = [];
+            for info in zClientFile.infolist():
+                files_on_client.append(info.filename)
+            missing_client_files = [x for x in files_on_server if x not in files_on_client]
+            
+            if missing_client_files != []:
+              logger.info("list all missing files in {}, which will be deleted on the server: {}.".format(filename, missing_client_files))
+
+            for x in missing_client_files:                
+                if x.endswith('/'):
+                    search_dir= os.path.dirname(x[:-1]) + '/'
+                    if search_dir not in missing_client_files:
+                        logger.debug("delete directory on the server: {0}.".format(x))
+                        delete(isamAppliance, x, "directory", check_mode=check_mode)
+                else:
+                    search_dir= os.path.dirname(x) + '/'
+                    if search_dir not in missing_client_files:
+                        logger.debug("delete file on the server: {0}.".format(x))
+                        delete(isamAppliance, x, "file", check_mode=check_mode)
+            shutil.rmtree(tempdir)
+
+        if check_mode is True:
+            return isamAppliance.create_return_object(changed=True)
+        else:
+            return isamAppliance.invoke_post_files(
+                "Replace all Runtime Template Files",
+                uri,
+                [
+                    {
+                        'file_formfield': 'file',
+                        'filename': filename,
+                        'mimetype': 'application/octet-stream'
+                    }
+                ],
                 {
-                    'file_formfield': 'file',
-                    'filename': filename,
-                    'mimetype': 'application/octet-stream'
-                }
-            ],
-            {
-                "force": force
-            }, json_response=False, requires_modules=requires_modules,
-            requires_version=requires_version)
+                    "force": force
+                }, json_response=False)
+
+    return isamAppliance.create_return_object(warnings=warnings)
+
+
+def _check_import(isamAppliance, filename):
+    """
+    Checks if runtime template zip from server and client differ
+    :param isamAppliance:
+    :param filename:
+    :return:
+    """
+
+    tempdir = get_random_temp_dir()
+    tempfilename = "template_files.zip"
+    tempfile =  os.path.join(tempdir, tempfilename)
+    export_file(isamAppliance, tempfile)
+    
+    if os.path.exists(tempfile):
+      identical = files_same_zip_content(filename,tempfile)
+    
+      shutil.rmtree(tempdir)
+      if identical:
+          logger.info("runtime template files {} are identical with the server content. No update necessary.".format(filename))
+          return False
+      else:
+          logger.info("runtime template files {} differ from the server content. Updating runtime template files necessary.".format(filename))
+          return True
+    else:
+      logger.info("missing zip file from server. Comparison skipped.")
+      return False
+
 
 
 def check(isamAppliance, id, type, check_mode=False, force=False):
     ret_obj = None
 
+    name = os.path.basename(id)
+    path = os.path.dirname(id)
+
     if (type.lower() == 'directory'):
         ret_obj = directory._check(isamAppliance, id)
     elif (type.lower() == 'file'):
-        ret_obj = file._check(isamAppliance, id)
+        ret_obj = file._check(isamAppliance, path, name)
     else:
         type = 'unknown'
-
-    name = os.path.basename(id)
-    path = os.path.dirname(id)
 
     data = {
         'id': ret_obj,
@@ -85,7 +156,11 @@ def delete(isamAppliance, id, type, check_mode=False, force=False):
     :param force:
     :return:
     """
-    if (type.lower() == 'directory'):
-        return directory.delete(isamAppliance, id)
-    elif (type.lower() == 'file'):
-        return file.delete(isamAppliance, id)
+    
+    name = os.path.basename(id)
+    path = os.path.dirname(id)
+    
+    if(type.lower() == 'directory'):
+      return directory.delete(isamAppliance, id, check_mode, force)
+    elif(type.lower() == 'file'):
+      return file.delete(isamAppliance, path, name, check_mode, force)

--- a/ibmsecurity/isam/web/reverse_proxy/management_root/all.py
+++ b/ibmsecurity/isam/web/reverse_proxy/management_root/all.py
@@ -1,8 +1,12 @@
 import logging
 import ibmsecurity.utilities.tools
 import os.path
+import shutil
+import zipfile
 from ibmsecurity.isam.web.reverse_proxy.management_root import directory
 from ibmsecurity.isam.web.reverse_proxy.management_root import file
+from ibmsecurity.isam.web.reverse_proxy import instance
+from ibmsecurity.utilities.tools import get_random_temp_dir, files_same_zip_content
 
 logger = logging.getLogger(__name__)
 
@@ -22,50 +26,113 @@ def export_zip(isamAppliance, instance_id, filename, check_mode=False, force=Fal
         if check_mode is False:
             return isamAppliance.invoke_get_file(
                 "Exporting the contents of the administration pages root as a .zip file",
-                "/wga/reverseproxy/{0}/management_root?index=&name=&enc_name=&type=&browser=".format(instance_id),
-                filename)
+                "/wga/reverseproxy/{0}/management_root/?export=true".format(instance_id),
+                filename, no_headers=True)
 
     return isamAppliance.create_return_object()
 
 
-def import_zip(isamAppliance, instance_id, filename, check_mode=False, force=False):
+def import_zip(isamAppliance, instance_id, filename, delete_missing=False, check_mode=False, force=False):
     """
     Importing the contents of a .zip file to the administration pages root
     """
-    if check_mode is True:
-        return isamAppliance.create_return_object(changed=True)
-    else:
-        return isamAppliance.invoke_post_files(
-            "Importing the contents of a .zip file to the administration pages root",
-            "/wga/reverseproxy/{0}/management_root".format(instance_id),
-            [
-                {
-                    'file_formfield': 'file',
-                    'filename': filename,
-                    'mimetype': 'application/octet-stream'
-                }
-            ],
-            {
-                'type': 'file',
-                'force': force
-            })
+    warnings = []
 
+    if force is True or _check_import(isamAppliance, instance_id, filename):
+        if delete_missing is True:
+            tempdir = get_random_temp_dir()
+            tempfilename = "management_root.zip"
+            tempfile =  os.path.join(tempdir, tempfilename)
+            export_zip(isamAppliance, instance_id, tempfile)
+
+            zServerFile = zipfile.ZipFile(tempfile)
+            zClientFile = zipfile.ZipFile(filename)
+
+            files_on_server = [];
+            for info in zServerFile.infolist():
+                files_on_server.append(info.filename)
+            files_on_client = [];
+            for info in zClientFile.infolist():
+                files_on_client.append(info.filename)
+            missing_client_files = [x for x in files_on_server if x not in files_on_client]
+
+            if missing_client_files != []:
+                logger.info("list all missing files in {}, which will be deleted on the server: {}.".format(filename, missing_client_files))
+
+            for x in missing_client_files:                
+                if x.endswith('/'):
+                    search_dir= os.path.dirname(x[:-1]) + '/'
+                    if search_dir not in missing_client_files:
+                        logger.debug("delete directory on the server: {0}.".format(x))
+                        directory.delete(isamAppliance, instance_id, x, check_mode=check_mode)
+                else:
+                    search_dir= os.path.dirname(x) + '/'
+                    if search_dir not in missing_client_files:
+                        logger.debug("delete file on the server: {0}.".format(x))
+                        file.delete(isamAppliance, instance_id, x, check_mode=check_mode)
+            shutil.rmtree(tempdir)
+
+        if check_mode is True:
+            return isamAppliance.create_return_object(changed=True)
+        else:
+            return isamAppliance.invoke_post_files(
+                "Importing the contents of a .zip file to the administration pages root",
+                 "/wga/reverseproxy/{0}/management_root".format(instance_id),
+                [
+                    {
+                        'file_formfield': 'file',
+                        'filename': filename,
+                        'mimetype': 'application/octet-stream'
+                    }
+                ],
+                {
+                    "force": force
+                }, json_response=False)
+
+    return isamAppliance.create_return_object(warnings=warnings)
+
+def _check_import(isamAppliance, instance_id, filename):
+    """
+    Checks if runtime template zip from server and client differ
+    :param isamAppliance:
+    :param filename:
+    :return:
+    """
+
+    if not instance._check(isamAppliance, instance_id):
+      logger.info("instance {} does not exist on this server. Skip import".format(instance_id))
+      return False
+
+    tempdir = get_random_temp_dir()
+    tempfilename = "management_root.zip"
+    tempfile =  os.path.join(tempdir, tempfilename)
+    export_zip(isamAppliance, instance_id, tempfile)
+
+    identical = files_same_zip_content(filename,tempfile)
+
+    shutil.rmtree(tempdir)
+    if identical:
+        logger.info("management_root files {} are identical with the server content. No update necessary.".format(filename))
+        return False
+    else:
+        logger.info("management_root files {} differ from the server content. Updating management_root files necessary.".format(filename))
+        return True
 
 def check(isamAppliance, instance_id, id, name, type, check_mode=False, force=False):
-    ret_obj = None
+  ret_obj = None
 
-    if (type.lower() == 'directory'):
-        ret_obj = directory._check(isamAppliance, instance_id, id, name)
-    elif (type.lower() == 'file'):
-        ret_obj = file._check(isamAppliance, instance_id, id, name)
-    else:
-        type = 'unknown'
+  if(type.lower() == 'directory'):
+    ret_obj = directory._check(isamAppliance, instance_id, id, name)
+  elif(type.lower() == 'file'):
+    ret_obj = file._check(isamAppliance, instance_id, id, name)
+  else:
+    type = 'unknown'
 
-    data = {
-        'id': ret_obj,
-        'top': id,
-        'name': name,
-        'type': type
-    }
+  data = {
+      'id': ret_obj,
+      'top': id,
+      'name': name,
+      'type': type
+  }
 
-    return isamAppliance.create_return_object(data=data)
+  return isamAppliance.create_return_object(data=data)

--- a/ibmsecurity/utilities/tools.py
+++ b/ibmsecurity/utilities/tools.py
@@ -6,6 +6,7 @@ import difflib
 import hashlib
 import ntpath
 import re
+import zipfile
 
 logger = logging.getLogger(__name__)
 
@@ -176,7 +177,39 @@ def files_same(original_file, new_file):
         return True
     else:
         return False
+        
+def files_same_zip_content(original_file, new_file):
+    identical = True
+        
+    z1 = zipfile.ZipFile(open(original_file))
+    z2 = zipfile.ZipFile(open(new_file))
+    
+    if len(z1.infolist()) != len(z2.infolist()):
+        logger.debug("number of archive elements differ: {} in {} vs {} from server".format(len(z1.infolist()), z1.filename, len(z2.infolist())))
+        identical = False
+        # Can stop comparison of zip files for perfomance
+        return identical
+    for zipentry in z1.infolist():
+        if zipentry.filename not in z2.namelist():
+            logger.debug("no file named {} found in {}".format(zipentry.filename, z2.filename))
+            identical = False
+        else:
+            with z1.open(zipentry.filename) as f:
+                original_file_contents = f.read()
+            with z2.open(zipentry.filename) as f:
+                new_file_contents = f.read()
+            hash_original_file = hashlib.sha224(original_file_contents).hexdigest()
+            hash_new_file = hashlib.sha224(new_file_contents).hexdigest()
+            if hash_original_file != hash_new_file:
+                identical = False
+                logger.debug("content for zip file {} differs.".format(zipentry.filename))
 
+    if identical:
+        logger.info("content for zip files {} and {} are the same.".format(original_file,new_file))
+    else:
+        logger.info("content for zip files {} and {} are different.".format(original_file,new_file))
+
+    return identical
 
 def get_random_temp_dir():
     """


### PR DESCRIPTION
BugFixes:
  - runtime_template root: add check_mode and force parameter to be passed through delete call
  - runtime_template file: File checker should compare to None, otherwise if id=0 the check would generate a false positive

Features:
  - Directory create with id function added (directory.py)
  - perform compare checks for zip on: (tools.py)
    - number of files
    - file content comparison one by one
  - +1 function: check runtime template root for idempotency
    adding verification check on runtime template root files between server and zip in import_file function. (makes use of new function: files_same_zip_content in ibmsecurity.utilities.tools)
  - +1 function: check management root on import_zip for idempotency
    adding verification check on management root files between server and zip in import_file function. (makes use of new function: files_same_zip_content in ibmsecurity.utilities.tools)