### PR TITLE
BugFix: load of signer certificates not possible(network or firewall restrictions)

### DIFF
--- a/ibmsecurity/isam/base/ssl_certificates/signer_certificate.py
+++ b/ibmsecurity/isam/base/ssl_certificates/signer_certificate.py
@@ -22,11 +22,19 @@ def get(isamAppliance, kdb_id, cert_id, check_mode=False, force=False):
                                     "/isam/ssl_certificates/{0}/signer_cert/{1}".format(kdb_id, cert_id))
 
 
-def load(isamAppliance, kdb_id, label, server, port, check_mode=False, force=False):
+def load(isamAppliance, kdb_id, label, server, port, check_remote=False, check_mode=False, force=False):
     """
     Load a certificate from a server
+    
+    check_remote controls if ansible should check remote certificate by retrieving it or simply by 
+    checking for existence of the label in the kdb
     """
-    if force is True or _check_load(isamAppliance, kdb_id, label, server, port) is False:
+    if check_remote:
+      tmp_check = _check_load(isamAppliance, kdb_id, label, server, port)
+    else:
+      tmp_check = _check(isamAppliance, kdb_id, label)
+    
+    if force is True or tmp_check is False:
         if check_mode is True:
             return isamAppliance.create_return_object(changed=True)
         else:
@@ -105,18 +113,9 @@ def delete(isamAppliance, kdb_id, cert_id, check_mode=False, force=False):
         if check_mode is True:
             return isamAppliance.create_return_object(changed=True)
         else:
-            try:
-                # Assume Python3 and import package
-                from urllib.parse import quote
-            except ImportError:
-                # Now try to import Python2 package
-                from urllib import quote
-
-            # URL being encoded primarily to handle spaces and other special characers in them
-            f_uri = "/isam/ssl_certificates/{0}/signer_cert/{1}".format(kdb_id, cert_id)
-            full_uri = quote(f_uri)
             return isamAppliance.invoke_delete(
-                "Deleting a signer certificate from a certificate database", full_uri)
+                "Deleting a signer certificate from a certificate database",
+                "/isam/ssl_certificates/{0}/signer_cert/{1}".format(kdb_id, cert_id))
 
     return isamAppliance.create_return_object()
 


### PR DESCRIPTION
load of signer certificates had following issues:
-  loading of local runtime certificates not possible (e.g. ansible can not reach local aac runtime certificate for checking)
- ansible is required to be able to load the certificate for comparison (firewall restrictions can prevent this to work properly)

fix: additional parameter  "check_remote" introduces.
description: parameter "check_remote" controls whether to load remote certificate into ansible for comparison or to simply compare the kdb for existance of the label. For backward compatibility and default behavior (LMI) reasons "check_remote" parameter is set to False by default.

Previous commit (https://github.com/IBM-Security/ibmsecurity/commit/c3b3522af60d9beff8299f7e58d7b1cbd050fb32) broke customer implementations, where firewall blocked the load of the remote certificates from the ansible server.