### PR TITLE
New function to Export junctions to YAML files

### DIFF
--- a/ibmsecurity/isam/web/reverse_proxy/junctions.py
+++ b/ibmsecurity/isam/web/reverse_proxy/junctions.py
@@ -129,6 +129,13 @@ def export(isamAppliance, reverseproxy_id, junctionname, file, check_mode=False,
     f = open(file_path + "/" + junctionname +".0", "w")   
     f.write(attrPrefix + "reverseproxy_id: " + reverseproxy_id +"\n")  
     #f.write(attrPrefix + "junction_point: " + junctionname +"\n")  
+    if junction_data['forms_based_sso'].lower == "disabled":
+        junction_data['forms_based_sso']=""
+    if junction_data['fsso_config_file'].lower == "disabled":
+        junction_data['forms_based_sso']=""
+ 
+
+    
     for mykey in junction_data:
         #logger.debug("Junction attr: " + str(mykey) + " / " + junction_data[mykey])
         #rename auth_http_header and fix data
@@ -144,11 +151,16 @@ def export(isamAppliance, reverseproxy_id, junctionname, file, check_mode=False,
             #process 1st junctioned server
             while i < 1:
                 #print(server[i])
+                del junction_data["servers"][i]['server_state']
+                del junction_data["servers"][i]['operation_state']
+
                 for skey in junction_data["servers"][i]:
                  f.write(attrPrefix + skey + ": " + junction_data["servers"][i][skey]+"\n") 
                 i += 1
             #process additional servers, new file
             while i < len(junction_data["servers"]):
+                del junction_data["servers"][i]['server_state']
+                del junction_data["servers"][i]['operation_state']                
                 fi = open(file_path + "/" + junctionname + "." + str(i), "w") 
                 fi.write(junctionPrefix + "reverseproxy_id: " + reverseproxy_id +"\n")  
                 fi.write(junctionPrefix + "junction_point: " + junctionname +"\n") 

--- a/ibmsecurity/isam/web/reverse_proxy/junctions.py
+++ b/ibmsecurity/isam/web/reverse_proxy/junctions.py
@@ -71,23 +71,25 @@ def get(isamAppliance, reverseproxy_id, junctionname, check_mode=False, force=Fa
 
     return ret_obj
 
-def export(isamAppliance, reverseproxy_id, junctionname, file, check_mode=False, force=False):
+
+def export(isamAppliance, reverseproxy_id, junctionname, export_dir, junction_prefix, check_mode=False, force=False):
     """
     Retrieving the parameters for a single standard or virtual junction
 
     :param isamAppliance:
     :param reverseproxy_id:
     :param junctionname:
-    :param file:  
+    :param export_dir: 
+    :param junction_prefix: 
     :param check_mode:
     :param force:
     :return:
     """
     ignoreAttrs = {'current_requests', 'operation_state', 'server_state'}     
-    junctionPrefix = "add_junction_"
+    junction_prefix = "add_junction_"
     serverPrefix="add_junction_"
     
-    file_path = file + reverseproxy_id
+    file_path = export_dir + reverseproxy_id
     file_path = file_path.strip()
     directory = os.path.dirname(file_path)
     if not os.path.exists(directory):
@@ -154,7 +156,7 @@ def export(isamAppliance, reverseproxy_id, junctionname, file, check_mode=False,
     for mykey in junction_data:              
         junction_data[mykey]=str(junction_data[mykey]).lower().replace("unknown","")
         junction_data[mykey]=str(junction_data[mykey]).lower().replace("disabled","")
-        f.write(junctionPrefix + mykey +": " + str(junction_data[mykey]).lower() +"\n")    
+        f.write(junction_prefix + mykey +": " + str(junction_data[mykey]).lower() +"\n")    
     f.close()  
     
      #process additional servers, new file

--- a/ibmsecurity/isam/web/reverse_proxy/junctions.py
+++ b/ibmsecurity/isam/web/reverse_proxy/junctions.py
@@ -86,10 +86,9 @@ def export(isamAppliance, reverseproxy_id, junctionname, export_dir, junction_pr
     :return:
     """
     ignoreAttrs = {'current_requests', 'operation_state', 'server_state'}     
-    junction_prefix = "add_junction_"
     serverPrefix="add_junction_"
     
-    file_path = export_dir + reverseproxy_id
+    file_path = export_dir +"/"+ reverseproxy_id
     file_path = file_path.strip()
     directory = os.path.dirname(file_path)
     if not os.path.exists(directory):

--- a/testisam_export_junction.py
+++ b/testisam_export_junction.py
@@ -91,12 +91,5 @@ if __name__ == "__main__":
     
    #junction_data=ibmsecurity.isam.web.reverse_proxy.junctions.get(isamAppliance=isam_server,junctionname="/fin_acc",reverseproxy_id="account01")
     junction_data=ibmsecurity.isam.web.reverse_proxy.junctions.export(isamAppliance=isam_server,junctionname="/fin_acc",reverseproxy_id="account01",export_dir="/tmp/",junction_prefix="add_junctions_")
-    p(junction_data)
-    print(junction_data)
-    import unicodedata
-    print(junction_data['data']['junction_point'])
-    import json
-    # convert into JSON:
-    y = json.dumps(junction_data)
-    print(y)
+  
 

--- a/testisam_export_junction.py
+++ b/testisam_export_junction.py
@@ -1,0 +1,102 @@
+import logging.config
+import pprint
+from ibmsecurity.appliance.isamappliance import ISAMAppliance
+from ibmsecurity.user.applianceuser import ApplianceUser
+import pkgutil
+import importlib
+
+
+def import_submodules(package, recursive=True):
+    """
+    Import all submodules of a module, recursively, including subpackages
+
+    :param package: package (name or actual module)
+    :type package: str | module
+    :rtype: dict[str, types.ModuleType]
+    """
+    if isinstance(package, str):
+        package = importlib.import_module(package)
+    results = {}
+    for loader, name, is_pkg in pkgutil.walk_packages(package.__path__):
+        full_name = package.__name__ + '.' + name
+        results[full_name] = importlib.import_module(full_name)
+        if recursive and is_pkg:
+            results.update(import_submodules(full_name))
+    return results
+
+
+import ibmsecurity
+
+# Import all packages within ibmsecurity - recursively
+# Note: Advisable to replace this code with specific imports for production code
+import_submodules(ibmsecurity)
+
+# Setup logging to send to stdout, format and set log level
+# logging.getLogger(__name__).addHandler(logging.NullHandler())
+logging.basicConfig()
+# Valid values are 'DEBUG', 'INFO', 'ERROR', 'CRITICAL'
+logLevel = 'DEBUG'
+DEFAULT_LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'formatters': {
+        'standard': {
+            'format': '[%(asctime)s] [PID:%(process)d TID:%(thread)d] [%(levelname)s] [%(name)s] [%(funcName)s():%(lineno)s] %(message)s'
+        },
+    },
+    'handlers': {
+        'default': {
+            'level': logLevel,
+            'formatter': 'standard',
+            'class': 'logging.StreamHandler',
+        },
+    },
+    'loggers': {
+        '': {
+            'level': logLevel,
+            'handlers': ['default'],
+            'propagate': True
+        },
+        'requests.packages.urllib3.connectionpool': {
+            'level': 'ERROR',
+            'handlers': ['default'],
+            'propagate': True
+        }
+    }
+}
+logging.config.dictConfig(DEFAULT_LOGGING)
+
+
+# Function to pretty print JSON data
+def p(jdata):
+    pp = pprint.PrettyPrinter(indent=2)
+    pp.pprint(jdata)
+
+if __name__ == "__main__":
+    """
+    This test program should not execute when imported, which would otherwise
+    cause problems when generating the documentation.
+    """
+    # Create a user credential for ISAM appliance
+    u = ApplianceUser(username="admin@local", password="admin")
+    # Create an ISAM appliance with above credential
+    isam_server = ISAMAppliance(hostname="192.168.1.2", user=u, lmi_port=443)
+
+    # Get the current SNMP monitoring setup details
+    p(ibmsecurity.isam.base.snmp_monitoring.get(isamAppliance=isam_server))
+    # Set the V2 SNMP monitoring
+    p(ibmsecurity.isam.base.snmp_monitoring.set_v1v2(isamAppliance=isam_server, community="IBM"))
+    # Commit or Deploy the changes
+    p(ibmsecurity.isam.appliance.commit(isamAppliance=isam_server))
+    
+   #junction_data=ibmsecurity.isam.web.reverse_proxy.junctions.get(isamAppliance=isam_server,junctionname="/fin_acc",reverseproxy_id="account01")
+    junction_data=ibmsecurity.isam.web.reverse_proxy.junctions.export(isamAppliance=isam_server,junctionname="/fin_acc",reverseproxy_id="account01",export_dir="/tmp/",junction_prefix="add_junctions_")
+    p(junction_data)
+    print(junction_data)
+    import unicodedata
+    print(junction_data['data']['junction_point'])
+    import json
+    # convert into JSON:
+    y = json.dumps(junction_data)
+    print(y)
+


### PR DESCRIPTION
Code reorganised and re-submitted: -

added export facility to isam.reverse_proxy.junctions, testisam_export_junction.py can be amended to demonstrate single call.

There is a new role in my fork of isam-ansible-roles.
https://github.com/vcassidy/isam-ansible-roles

I have also added new playbooks to the samples for export_junction_details.yml, add_junction.yml and add_junction_server.yml (i.e. add a server to an existing junction): -
https://github.com/vcassidy/isam-ansible-playbook-sample

If the export is accepted I will add pull requests for these 2 forks also

Happy to discuss code and work on any recommendations. Creates a file for each server on a junction. Handles add_junction, set_junction and add_junction_server. 