### PR TITLE
Fixes for web runtime and reverse proxy configuration entry.

### DIFF
--- a/ibmsecurity/isam/web/reverse_proxy/configuration/entry.py
+++ b/ibmsecurity/isam/web/reverse_proxy/configuration/entry.py
@@ -104,12 +104,10 @@ def set(isamAppliance, reverseproxy_id, stanza_id, entries, check_mode=False, fo
             elif update_required is True:
                 set_update = True
                 process_entry = True
-                for val in cur_value:
-                    # Force delete of existing values, new values will be added
-                    logger.info(
-                        'Deleting entry, will be re-added: {0}/{1}/{2}/{3}'.format(reverseproxy_id, stanza_id, entry[0],
-                                                                                   val))
-                    delete(isamAppliance, reverseproxy_id, stanza_id, entry[0], val, check_mode, True)
+                # Force delete of existing values, new values will be added
+                logger.info(
+                    'Deleting entry, will be re-added: {0}/{1}/{2}'.format(reverseproxy_id, stanza_id, entry[0]))
+                delete_all(isamAppliance, reverseproxy_id, stanza_id, entry[0], check_mode, True)
             if process_entry is True:
                 if isinstance(entry[1], list):
                     for v in entry[1]:
@@ -178,6 +176,11 @@ def delete(isamAppliance, reverseproxy_id, stanza_id, entry_id, value_id='', che
                 from urllib import quote
 
             full_uri = quote(ruri)
+            ### Workaround for value_id encoding in 9.0.7.1
+            if ibmsecurity.utilities.tools.version_compare(isamAppliance.facts['version'], '9.0.7.1') >= 0:
+                uri_parts = full_uri.split('/value/')
+                uri_parts[1] = uri_parts[1].replace('/', '%2F')
+                full_uri = '/value/'.join(uri_parts)
             return isamAppliance.invoke_delete(
                 "Deleting a value from a configuration entry - Reverse Proxy", full_uri)
 

--- a/ibmsecurity/isam/web/runtime/configuration/entry.py
+++ b/ibmsecurity/isam/web/runtime/configuration/entry.py
@@ -97,12 +97,10 @@ def set(isamAppliance, resource_id, stanza_id, entries, check_mode=False, force=
             elif update_required is True:  # Existing entries need to be updated
                 set_update = True
                 process_entry = True
-                for val in cur_value:
-                    # Force delete of existing values, new values will be added
-                    logger.info(
-                        'Deleting entry, will be re-added: {0}/{1}/{2}/{3}'.format(resource_id, stanza_id, entry[0],
-                                                                                   val))
-                    delete(isamAppliance, resource_id, stanza_id, entry[0], val, check_mode, True)
+                # Force delete of existing values, new values will be added
+                logger.info(
+                    'Deleting entry, will be re-added: {0}/{1}/{2}'.format(resource_id, stanza_id, entry[0]))
+                delete_all(isamAppliance, resource_id, stanza_id, entry[0], check_mode, True)
             if process_entry is True:
                 if isinstance(entry[1], list):
                     for v in entry[1]:
@@ -135,9 +133,9 @@ def _collapse_entries(entries):
         if entry[0] == cur_key:
             cur_value.append(entry[1])
         else:
+            new_entry.append([cur_key, cur_value])
             cur_key = entry[0]
             cur_value = [entry[1]]
-            new_entry.append([cur_key, cur_value])
 
     new_entry.append([cur_key, cur_value])
 


### PR DESCRIPTION
web/runtime/configuration/entry.py:
- set method: Refactor code to use delete_all method rather than individually deleting entry values.
- _collapse_entries method: Remediate a logic error when processing new entries which caused dropping the first entry and duplicating the last.

web/reverse_proxy/configuration/entry.py:
- set method: Refactor code to use delete_all method rather than individually deleting entry values.
- delete method: Incorporate a fix for ISAM 9.0.7.1 similar to pull request 228 for issue 230.
