### PR TITLE
Bugfix: Regression error caused by changes to interfaces.py

### DIFF
--- a/ibmsecurity/isam/base/network/interfaces_ipv4.py
+++ b/ibmsecurity/isam/base/network/interfaces_ipv4.py
@@ -15,7 +15,7 @@ def add(isamAppliance, label, address, maskOrPrefix, overrideSubnetChecking=Fals
     ret_obj = {}
     warnings = []
     if force is False:
-        ret_obj = ibmsecurity.isam.base.network.interfaces._get_interface(isamAppliance, label, vlanId)
+        ret_obj, warnings = ibmsecurity.isam.base.network.interfaces._get_interface(isamAppliance, label, vlanId)
         if ret_obj is not None:
             del ret_obj['objType']
             del ret_obj['type']
@@ -56,7 +56,7 @@ def delete(isamAppliance, label, address, vlanId=None, check_mode=False, force=F
     ret_obj = {}
     warnings = []
     if force is False:
-        ret_obj = ibmsecurity.isam.base.network.interfaces._get_interface(isamAppliance, label, vlanId)
+        ret_obj, warnings = ibmsecurity.isam.base.network.interfaces._get_interface(isamAppliance, label, vlanId)
         if ret_obj is not None:
             for addr in ret_obj['ipv4']['addresses']:
                 if addr['address'] == address:
@@ -85,7 +85,7 @@ def update(isamAppliance, label, address, new_address, maskOrPrefix, vlanId=None
     ret_obj = {}
     warnings = []
     if force is False:
-        ret_obj = ibmsecurity.isam.base.network.interfaces._get_interface(isamAppliance, label, vlanId)
+        ret_obj, warnings = ibmsecurity.isam.base.network.interfaces._get_interface(isamAppliance, label, vlanId)
         if ret_obj is not None:
             for addr in ret_obj['ipv4']['addresses']:
                 if addr['address'] == address:
@@ -126,7 +126,7 @@ def set_dhcp(isamAppliance, label, vlanId=None, enabled=False, allowManagement=F
     ret_obj = {}
     warnings = []
     if force is False:
-        ret_obj = ibmsecurity.isam.base.network.interfaces._get_interface(isamAppliance, label, vlanId)
+        ret_obj, warnings = ibmsecurity.isam.base.network.interfaces._get_interface(isamAppliance, label, vlanId)
         if ret_obj is not None:
             upd_dhcp = {
                 'enabled': enabled,

--- a/ibmsecurity/isam/base/network/interfaces_ipv6.py
+++ b/ibmsecurity/isam/base/network/interfaces_ipv6.py
@@ -15,7 +15,7 @@ def add(isamAppliance, label, address, prefixLength, vlanId=None, allowManagemen
     ret_obj = {}
     warnings = []
     if force is False:
-        ret_obj = ibmsecurity.isam.base.network.interfaces._get_interface(isamAppliance, label, vlanId)
+        ret_obj, warnings = ibmsecurity.isam.base.network.interfaces._get_interface(isamAppliance, label, vlanId)
         if ret_obj is not None:
             del ret_obj['objType']
             del ret_obj['type']
@@ -60,7 +60,7 @@ def delete(isamAppliance, label, address, vlanId=None, check_mode=False, force=F
     ret_obj = {}
     warnings = []
     if force is False:
-        ret_obj = ibmsecurity.isam.base.network.interfaces._get_interface(isamAppliance, label, vlanId)
+        ret_obj, warnings = ibmsecurity.isam.base.network.interfaces._get_interface(isamAppliance, label, vlanId)
         if ret_obj is not None:
             for addr in ret_obj['ipv6']['addresses']:
                 if addr['address'] == address:
@@ -89,7 +89,7 @@ def update(isamAppliance, label, address, new_address, prefixLength, vlanId=None
     ret_obj = {}
     warnings = []
     if force is False:
-        ret_obj = ibmsecurity.isam.base.network.interfaces._get_interface(isamAppliance, label, vlanId)
+        ret_obj, warnings = ibmsecurity.isam.base.network.interfaces._get_interface(isamAppliance, label, vlanId)
         if ret_obj is not None:
             for addr in ret_obj['ipv6']['addresses']:
                 if addr['address'] == address:
@@ -129,7 +129,7 @@ def set_dhcp(isamAppliance, label, vlanId=None, enabled=False, allowManagement=F
     ret_obj = {}
     warnings = []
     if force is False:
-        ret_obj = ibmsecurity.isam.base.network.interfaces._get_interface(isamAppliance, label, vlanId)
+        ret_obj, warnings = ibmsecurity.isam.base.network.interfaces._get_interface(isamAppliance, label, vlanId)
         if ret_obj is not None:
             upd_dhcp = {
                 'enabled': enabled,


### PR DESCRIPTION
The interfaces._get_interface method return was changed to add warnings.  interfaces_ipv4.py and interfaces_ipv6 have a dependency on this method.  This fix adds warnings to the return assignment of the methods that make these calls: add, delete, update, and set_dhcp.