### PR TITLE
Bugfix: realms_property idempotency fixes

### DIFF
--- a/ibmsecurity/isam/web/kerberos_configuration/realms_property.py
+++ b/ibmsecurity/isam/web/kerberos_configuration/realms_property.py
@@ -156,14 +156,10 @@ def update(isamAppliance, realm, propname, propvalue, subsection=None, check_mod
 
     needs_update = False
 
-    json_data = {
-        "name": "{0} = {1}".format(propname, propvalue)
-    }
+    propstring = "{0} = {1}".format(propname, propvalue)
 
     if force is not True:
-        import ibmsecurity.utilities.tools
-        if ibmsecurity.utilities.tools.json_sort(ret_obj['data']) != ibmsecurity.utilities.tools.json_sort(
-                json_data):
+        if ret_obj['data']['name'] != propstring:
             needs_update = True
 
     if force is True or needs_update is True:

--- a/ibmsecurity/isam/web/kerberos_configuration/realms_property.py
+++ b/ibmsecurity/isam/web/kerberos_configuration/realms_property.py
@@ -29,12 +29,14 @@ def search(isamAppliance, realm, propname, subsection=None, includeValuesInLine=
 
     return_obj = isamAppliance.create_return_object()
     return_obj["warnings"] = ret_obj["warnings"]
+    return_obj['data'] = {}
 
     for obj in ret_obj['data']:
         if obj['type'] == "property":
             if "{0} = ".format(propname) in obj['name']:
                 logger.info("Found Kerberos realm property {0} id: {1}".format(propname, obj['id']))
-                return_obj['data'] = obj['name']
+                return_obj['data']['name'] = obj['name']
+                return_obj['data']['id'] = obj['id']
                 return_obj['rc'] = 0
                 break
 
@@ -54,7 +56,7 @@ def _check(isamAppliance, realm, propname, propvalue, subsection=None):
     ret_obj = search(isamAppliance, realm, propname, subsection)
     logger.debug("Looking for existing kerberos property {0} in {1}".format(propname, ret_obj['data']))
     if ret_obj['data'] != {}:
-        if ret_obj['data'] == propstring:
+        if ret_obj['data']['name'] == propstring:
             logger.debug("Found kerberos property: {0} in : {1}".format(propname, ret_obj['data']))
             return True
     return False
@@ -79,7 +81,7 @@ def add(isamAppliance, realm, propname, propvalue, subsection=None, check_mode=F
         return isamAppliance.create_return_object(
             warnings=["Subsection: {0}/{1} does not exists.".format(realm, subsection)])
 
-    if _check(isamAppliance, realm, propname, propvalue, subsection) is True and force is False:
+    if force is False and _check(isamAppliance, realm, propname, propvalue, subsection) is True:
         return isamAppliance.create_return_object(
             warnings=["Property: {0} with value: {1} already exists: ".format(uriprop, propvalue)])
 


### PR DESCRIPTION
### Multiple changes to correct idempotency checks when used with Ansible module:
- search method: Initialize data property of return_obj to empty dictionary.  Set name and id properties when realm property is found.
- _check method: Change comparison logic to use name property of search result.
- add method: avoid second lookup when adding property from set method (when force is true)
- update method: change idempotency logic to use name property of search result instead of comparing dictionaries.