### PR TITLE
fixed URL for reverse proxy instance configuration import

### DIFF
--- a/ibmsecurity/isam/web/reverse_proxy/instance.py
+++ b/ibmsecurity/isam/web/reverse_proxy/instance.py
@@ -101,7 +101,7 @@ def import_config(isamAppliance, id, file, overwrite=True, check_mode=False, for
             return isamAppliance.create_return_object(changed=True)
         else:
             return isamAppliance.invoke_post_files(description="Import or Migrate reverse proxy",
-                                                   uri="{0}/{1}".format(uri, id),
+                                                   uri="{0}/{1}/migrate".format(uri, id),
                                                    fileinfo=[{
                                                        'file_formfield': 'file',
                                                        'filename': file,


### PR DESCRIPTION
The URL should be 
https://{appliance_hostname}/wga/reverseproxy/{instance_id}/migrate
and not just 
https://{appliance_hostname}/wga/reverseproxy/{instance_id}
as it was in the code.