### PR TITLE
Bug fix: added in a check in ibmsecurity/isam/base/cluster/configurat…

### DIFF
--- a/ibmsecurity/isam/base/cluster/configuration.py
+++ b/ibmsecurity/isam/base/cluster/configuration.py
@@ -138,7 +138,9 @@ def set(isamAppliance, primary_master='127.0.0.1', secondary_master=None, master
         cluster_json["dsc_trace_level"] = dsc_trace_level
 
     check_obj =  _check(isamAppliance, cluster_json, ignore_password_for_idempotency)
-    warnings.append(check_obj['warnings'])
+    if check_obj['warnings'] != []:
+        warnings.append(check_obj['warnings'][0])
+
     if force is True or check_obj['value'] is False:
         if check_mode is True:
             return isamAppliance.create_return_object(changed=True, warnings=warnings)


### PR DESCRIPTION
…ion.py set() after calling _check().  If the warnings returned from _check() is [], then it is not appended to the warnings object that is used in set().