### PR TITLE
BugFix: export_zip for management_root

### DIFF
--- a/ibmsecurity/isam/web/reverse_proxy/management_root/all.py
+++ b/ibmsecurity/isam/web/reverse_proxy/management_root/all.py
@@ -23,7 +23,7 @@ def export_zip(isamAppliance, instance_id, filename, check_mode=False, force=Fal
             return isamAppliance.invoke_get_file(
                 "Exporting the contents of the administration pages root as a .zip file",
                 "/wga/reverseproxy/{0}/management_root?index=&name=&enc_name=&type=&browser=".format(instance_id),
-                filename)
+                filename=filename,no_headers=True)
 
     return isamAppliance.create_return_object()
 


### PR DESCRIPTION
without the no_headers parameter the export_zip will get a JSON response from appliances instead of a ZIP file content.