### PR TITLE
BuxFix + Feature: compare and sync zip files local and server before import

### DIFF
--- a/ibmsecurity/isam/web/reverse_proxy/management_root/all.py
+++ b/ibmsecurity/isam/web/reverse_proxy/management_root/all.py
@@ -1,8 +1,12 @@
 import logging
 import ibmsecurity.utilities.tools
 import os.path
+import shutil
+import zipfile
 from ibmsecurity.isam.web.reverse_proxy.management_root import directory
 from ibmsecurity.isam.web.reverse_proxy.management_root import file
+from ibmsecurity.isam.web.reverse_proxy import instance
+from ibmsecurity.utilities.tools import get_random_temp_dir, files_same_zip_content
 
 logger = logging.getLogger(__name__)
 
@@ -23,33 +27,97 @@ def export_zip(isamAppliance, instance_id, filename, check_mode=False, force=Fal
             return isamAppliance.invoke_get_file(
                 "Exporting the contents of the administration pages root as a .zip file",
                 "/wga/reverseproxy/{0}/management_root?index=&name=&enc_name=&type=&browser=".format(instance_id),
-                filename)
+                filename=filename, no_headers=True)
 
     return isamAppliance.create_return_object()
 
 
-def import_zip(isamAppliance, instance_id, filename, check_mode=False, force=False):
+def import_zip(isamAppliance, instance_id, filename, delete_missing=False, check_mode=False, force=False):
     """
     Importing the contents of a .zip file to the administration pages root
+    Feature delete_missing will compare import zip with server content and delete missing files in the import zip from server
     """
-    if check_mode is True:
-        return isamAppliance.create_return_object(changed=True)
-    else:
-        return isamAppliance.invoke_post_files(
-            "Importing the contents of a .zip file to the administration pages root",
-            "/wga/reverseproxy/{0}/management_root".format(instance_id),
-            [
-                {
-                    'file_formfield': 'file',
-                    'filename': filename,
-                    'mimetype': 'application/octet-stream'
-                }
-            ],
-            {
-                'type': 'file',
-                'force': force
-            })
+    warnings = []
+    
+    if force is True or _check_import(isamAppliance, instance_id, filename):
+        if delete_missing is True:
+            tempdir = get_random_temp_dir()
+            tempfilename = "management_root.zip"
+            tempfile =  os.path.join(tempdir, tempfilename)
+            export_zip(isamAppliance, instance_id, tempfile)
 
+            zServerFile = zipfile.ZipFile(tempfile)
+            zClientFile = zipfile.ZipFile(filename)
+
+            files_on_server = [];
+            for info in zServerFile.infolist():
+                files_on_server.append(info.filename)
+            files_on_client = [];
+            for info in zClientFile.infolist():
+                files_on_client.append(info.filename)
+            missing_client_files = [x for x in files_on_server if x not in files_on_client]
+
+            if missing_client_files != []:
+                logger.info("list all missing files in {}, which will be deleted on the server: {}.".format(filename, missing_client_files))
+
+            for x in missing_client_files:                
+                if x.endswith('/'):
+                    search_dir= os.path.dirname(x[:-1]) + '/'
+                    if search_dir not in missing_client_files:
+                        logger.debug("delete directory on the server: {0}.".format(x))
+                        directory.delete(isamAppliance, instance_id, x, check_mode=check_mode)
+                else:
+                    search_dir= os.path.dirname(x) + '/'
+                    if search_dir not in missing_client_files:
+                        logger.debug("delete file on the server: {0}.".format(x))
+                        file.delete(isamAppliance, instance_id, x, check_mode=check_mode)
+            shutil.rmtree(tempdir)
+
+        if check_mode is True:
+            return isamAppliance.create_return_object(changed=True)
+        else:
+            return isamAppliance.invoke_post_files(
+                "Importing the contents of a .zip file to the administration pages root",
+                 "/wga/reverseproxy/{0}/management_root".format(instance_id),
+                [
+                    {
+                        'file_formfield': 'file',
+                        'filename': filename,
+                        'mimetype': 'application/octet-stream'
+                    }
+                ],
+                {
+                    "force": force
+                }, json_response=False)
+
+    return isamAppliance.create_return_object(warnings=warnings)
+
+def _check_import(isamAppliance, instance_id, filename):
+    """
+    Checks if runtime template zip from server and client differ
+    :param isamAppliance:
+    :param filename:
+    :return:
+    """
+
+    if not instance._check(isamAppliance, instance_id):
+      logger.info("instance {} does not exist on this server. Skip import".format(instance_id))
+      return False
+
+    tempdir = get_random_temp_dir()
+    tempfilename = "management_root.zip"
+    tempfile =  os.path.join(tempdir, tempfilename)
+    export_zip(isamAppliance, instance_id, tempfile)
+
+    identical = files_same_zip_content(filename,tempfile)
+
+    shutil.rmtree(tempdir)
+    if identical:
+        logger.info("management_root files {} are identical with the server content. No update necessary.".format(filename))
+        return False
+    else:
+        logger.info("management_root files {} differ from the server content. Updating management_root files necessary.".format(filename))
+        return True
 
 def check(isamAppliance, instance_id, id, name, type, check_mode=False, force=False):
     ret_obj = None

--- a/ibmsecurity/utilities/tools.py
+++ b/ibmsecurity/utilities/tools.py
@@ -7,6 +7,7 @@ import hashlib
 import ntpath
 import re
 from io import open
+import zipfile
 
 logger = logging.getLogger(__name__)
 
@@ -178,6 +179,38 @@ def files_same(original_file, new_file):
     else:
         return False
 
+def files_same_zip_content(original_file, new_file):
+    identical = True
+    logger.debug("Comparing original_file[{}] vs new_file[{}]".format(original_file, new_file))
+    z1 = zipfile.ZipFile(original_file)
+    z2 = zipfile.ZipFile(new_file)
+    
+    if len(z1.infolist()) != len(z2.infolist()):
+        logger.debug("number of archive elements differ: {} in {} vs {} from server".format(len(z1.infolist()), z1.filename, len(z2.infolist())))
+        identical = False
+        # Can stop comparison of zip files for perfomance
+        return identical
+    for zipentry in z1.infolist():
+        if zipentry.filename not in z2.namelist():
+            logger.debug("no file named {} found in {}".format(zipentry.filename, z2.filename))
+            identical = False
+        else:
+            with z1.open(zipentry.filename) as f:
+                original_file_contents = f.read()
+            with z2.open(zipentry.filename) as f:
+                new_file_contents = f.read()
+            hash_original_file = hashlib.sha224(original_file_contents).hexdigest()
+            hash_new_file = hashlib.sha224(new_file_contents).hexdigest()
+            if hash_original_file != hash_new_file:
+                identical = False
+                logger.debug("content for zip file {} differs.".format(zipentry.filename))
+
+    if identical:
+        logger.info("content for zip files {} and {} are the same.".format(original_file,new_file))
+    else:
+        logger.info("content for zip files {} and {} are different.".format(original_file,new_file))
+
+    return identical
 
 def get_random_temp_dir():
     """


### PR DESCRIPTION
BugFix: export_zip file creates only JSON as ZIP file content
- without the no_headers parameter the export_zip will get a JSON response from appliances instead of a ZIP file content.

Feature:
- perform compare checks for zip on: (tools.py)
    - number of files
    - file content comparison one by one
  - +1 function: check management root on import_zip for idempotency
    adding verification check on management root files between server and zip in import_file function of ibmsecurity\isam\web\reverse_proxy\management_root\all.py. Also capable of deleting server files which are missing in the local ZIP (default behavior for this feature it is disabled)