### PR TITLE
Set defaults for smtp search

### DIFF
--- a/ibmsecurity/isam/aac/server_connections/smtp.py
+++ b/ibmsecurity/isam/aac/server_connections/smtp.py
@@ -122,7 +122,7 @@ def _create_json(name, description, locked, connection, connectionManager):
     return json
 
 
-def search(isamAppliance, name):
+def search(isamAppliance, name, check_mode=False, force=False):
     """
     Retrieve UUID for named SMTP connection
     """


### PR DESCRIPTION
Set defaults for 'check_mode' and 'force' in the 'search' method of smtp.py