### PR TITLE
Feature: password idempotency for server connections

### DIFF
--- a/ibmsecurity/isam/aac/server_connections/ci.py
+++ b/ibmsecurity/isam/aac/server_connections/ci.py
@@ -1,9 +1,9 @@
 import logging
-import ibmsecurity.utilities.tools
+from ibmsecurity.utilities import tools
 
 logger = logging.getLogger(__name__)
 
-requires_modules = ["mga"]
+requires_modules = ["mga", "federation"]
 requires_version = "9.0.5.0"
 
 
@@ -31,7 +31,7 @@ def get(isamAppliance, name, check_mode=False, force=False):
                                         requires_modules=requires_modules, requires_version=requires_version)
 
 
-def set(isamAppliance, name, connection, description='', locked=False, new_name=None, check_mode=False, force=False):
+def set(isamAppliance, name, connection, description='', locked=False, new_name=None, ignore_password_for_idempotency=False, check_mode=False, force=False):
     """
     Creating or Modifying a CI server connection
     """
@@ -42,7 +42,7 @@ def set(isamAppliance, name, connection, description='', locked=False, new_name=
     else:
         # Update request
         return update(isamAppliance=isamAppliance, name=name, connection=connection, description=description,
-                      locked=locked, new_name=new_name, check_mode=check_mode, force=force)
+                      locked=locked, new_name=new_name, ignore_password_for_idempotency=ignore_password_for_idempotency, check_mode=check_mode, force=force)
 
 
 def add(isamAppliance, name, connection, description='', locked=False, check_mode=False, force=False):
@@ -81,27 +81,52 @@ def delete(isamAppliance, name, check_mode=False, force=False):
     return isamAppliance.create_return_object()
 
 
-def update(isamAppliance, name, connection, description='', locked=False, new_name=None, check_mode=False, force=False):
+def update(isamAppliance, name, connection, description='', locked=False, new_name=None, ignore_password_for_idempotency=False, check_mode=False, force=False):
     """
     Modifying a CI server connection
-    Use new_name to rename the connection, cannot compare password so update will take place everytime
+    Use new_name to rename the connection.
     """
+    ret_obj = get(isamAppliance, name)
+    warnings = ret_obj["warnings"]
 
-    if force is True or _check_exists(isamAppliance, name):
+    if ret_obj["data"] == {}:
+        warnings.append("CI server connection {0} not found, skipping update.".format(name))
+        return isamAppliance.create_return_object(warnings=warnings)
+    else:
+        id = ret_obj["data"]["uuid"]
+
+    needs_update = False
+
+    json_data = _create_json(name=name, description=description, locked=locked, connection=connection)
+    if new_name is not None:  # Rename condition
+        json_data['name'] = new_name
+
+    if force is not True:
+        if 'uuid' in ret_obj['data']:
+            del ret_obj['data']['uuid']
+        if ignore_password_for_idempotency:
+            if 'clientSecret' in connection:
+                warnings.append("Request made to ignore clientSecret for idempotency check.")
+                connection.pop('clientSecret', None)
+
+        sorted_ret_obj = tools.json_sort(ret_obj['data'])
+        sorted_json_data = tools.json_sort(json_data)
+        logger.debug("Sorted Existing Data:{0}".format(sorted_ret_obj))
+        logger.debug("Sorted Desired  Data:{0}".format(sorted_json_data))
+
+        if sorted_ret_obj != sorted_json_data:
+            needs_update = True
+
+    if force is True or needs_update is True:
         if check_mode is True:
-            return isamAppliance.create_return_object(changed=True)
+            return isamAppliance.create_return_object(changed=True, warnings=warnings)
         else:
-            json_data = _create_json(name=name, description=description, locked=locked, connection=connection)
-            if new_name is not None:  # Rename condition
-                json_data['name'] = new_name
-            ret_obj = search(isamAppliance, name=name)
-            id = ret_obj['data']
             return isamAppliance.invoke_put(
                 "Modifying a CI server connection",
                 "/mga/server_connections/ci/{0}/v1".format(id), json_data, requires_modules=requires_modules,
                 requires_version=requires_version)
 
-    return isamAppliance.create_return_object()
+    return isamAppliance.create_return_object(warnings=warnings)
 
 
 def _create_json(name, description, locked, connection):

--- a/ibmsecurity/isam/aac/server_connections/smtp.py
+++ b/ibmsecurity/isam/aac/server_connections/smtp.py
@@ -1,15 +1,18 @@
 import logging
-import ibmsecurity.utilities.tools
+from ibmsecurity.utilities import tools
 
 logger = logging.getLogger(__name__)
 
+requires_modules = ["mga", "federation"]
+requires_version = None
 
 def get_all(isamAppliance, check_mode=False, force=False):
     """
     Retrieving a list of all SMTP server connections
     """
     return isamAppliance.invoke_get("Retrieving a list of all SMTP server connections",
-                                    "/mga/server_connections/smtp/v1")
+                                    "/mga/server_connections/smtp/v1",
+                                    requires_modules=requires_modules, requires_version=requires_version)
 
 
 def get(isamAppliance, name, check_mode=False, force=False):
@@ -23,10 +26,11 @@ def get(isamAppliance, name, check_mode=False, force=False):
         return isamAppliance.create_return_object()
     else:
         return isamAppliance.invoke_get("Retrieving a SMTP server connection",
-                                        "/mga/server_connections/smtp/{0}/v1".format(id))
+                                        "/mga/server_connections/smtp/{0}/v1".format(id),
+                                        requires_modules=requires_modules, requires_version=requires_version)
 
 
-def set(isamAppliance, name, connection, description='', locked=False, connectionManager=None, new_name=None,
+def set(isamAppliance, name, connection, description='', locked=False, connectionManager=None, new_name=None, ignore_password_for_idempotency=False,
         check_mode=False, force=False):
     """
     Creating or Modifying an SMTP server connection
@@ -38,7 +42,7 @@ def set(isamAppliance, name, connection, description='', locked=False, connectio
     else:
         # Update request
         return update(isamAppliance=isamAppliance, name=name, connection=connection, description=description,
-                      locked=locked, connectionManager=connectionManager, new_name=new_name,
+                      locked=locked, connectionManager=connectionManager, new_name=new_name, ignore_password_for_idempotency=ignore_password_for_idempotency,
                       check_mode=check_mode, force=force)
 
 
@@ -55,7 +59,8 @@ def add(isamAppliance, name, connection, description='', locked=False, connectio
                 "Creating a SMTP server connection",
                 "/mga/server_connections/smtp/v1",
                 _create_json(name=name, description=description, locked=locked, connection=connection,
-                             connectionManager=connectionManager))
+                             connectionManager=connectionManager),
+                             requires_modules=requires_modules, requires_version=requires_version)
 
     return isamAppliance.create_return_object()
 
@@ -72,37 +77,58 @@ def delete(isamAppliance, name, check_mode=False, force=False):
             id = ret_obj['data']
             return isamAppliance.invoke_delete(
                 "Deleting a SMTP server connection",
-                "/mga/server_connections/smtp/{0}/v1".format(id))
+                "/mga/server_connections/smtp/{0}/v1".format(id),
+                requires_modules=requires_modules, requires_version=requires_version)
 
     return isamAppliance.create_return_object()
 
 
-def update(isamAppliance, name, connection, description='', locked=False, connectionManager=None, new_name=None,
+def update(isamAppliance, name, connection, description='', locked=False, connectionManager=None, new_name=None, ignore_password_for_idempotency=False,
            check_mode=False, force=False):
     """
     Modifying a SMTP server connection
 
-    Use new_name to rename the connection, cannot compare password so update will take place everytime
+    Use new_name to rename the connection.
     """
+    ret_obj = get(isamAppliance, name)
+    warnings = ret_obj["warnings"]
 
-    if force is True or _check_exists(isamAppliance, name):
+    if ret_obj["data"] == {}:
+        warnings.append("LDAP server connection {0} not found, skipping update.".format(name))
+        return isamAppliance.create_return_object(warnings=warnings)
+    else:
+        id = ret_obj["data"]["uuid"]
+
+    needs_update = False
+
+    json_data = _create_json(name=name, description=description, locked=locked, connection=connection, connectionManager=connectionManager)
+    if new_name is not None:  # Rename condition
+        json_data['name'] = new_name
+
+    if force is not True:
+        if 'uuid' in ret_obj['data']:
+            del ret_obj['data']['uuid']
+        if ignore_password_for_idempotency:
+            if 'password' in connection:
+                warnings.append("Request made to ignore password for idempotency check.")
+                connection.pop('password', None)
+
+        sorted_ret_obj = tools.json_sort(ret_obj['data'])
+        sorted_json_data = tools.json_sort(json_data)
+        logger.debug("Sorted Existing Data:{0}".format(sorted_ret_obj))
+        logger.debug("Sorted Desired  Data:{0}".format(sorted_json_data))
+
+        if sorted_ret_obj != sorted_json_data:
+            needs_update = True
+
+    if force is True or needs_update is True:
         if check_mode is True:
-            return isamAppliance.create_return_object(changed=True)
+            return isamAppliance.create_return_object(changed=True, warnings=warnings)
         else:
-            json_data = _create_json(name=name, description=description, locked=locked, connection=connection,
-                                     connectionManager=connectionManager)
-            if new_name is not None:  # Rename condition
-                json_data['name'] = new_name
-
-            ret_obj = search(isamAppliance, name=name)
-            id = ret_obj['data']
-
             return isamAppliance.invoke_put(
                 "Modifying a SMTP server connection",
-                "/mga/server_connections/smtp/{0}/v1".format(id), json_data)
-
-    return isamAppliance.create_return_object()
-
+                "/mga/server_connections/smtp/{0}/v1".format(id), json_data,
+                requires_modules=requires_modules, requires_version=requires_version, warnings=warnings)
 
 def _create_json(name, description, locked, connection, connectionManager):
     """

--- a/ibmsecurity/isam/aac/server_connections/ws.py
+++ b/ibmsecurity/isam/aac/server_connections/ws.py
@@ -1,5 +1,5 @@
 import logging
-import ibmsecurity.utilities.tools
+from ibmsecurity.utilities import tools
 
 logger = logging.getLogger(__name__)
 
@@ -88,7 +88,7 @@ def delete(isamAppliance, name, check_mode=False, force=False):
     return isamAppliance.create_return_object()
 
 
-def update(isamAppliance, name, connection, description='', locked=False, new_name=None,
+def update(isamAppliance, name, connection, description='', locked=False, new_name=None, ignore_password_for_idempotency=False,
            check_mode=False, force=False):
     """
     Modifying a Web Service connection
@@ -113,9 +113,13 @@ def update(isamAppliance, name, connection, description='', locked=False, new_na
     if force is not True:
         if 'uuid' in ret_obj['data']:
             del ret_obj['data']['uuid']
+        if ignore_password_for_idempotency:
+            if 'password' in connection:
+                warnings.append("Request made to ignore password for idempotency check.")
+                connection.pop('password', None)
 
-        sorted_ret_obj = ibmsecurity.utilities.tools.json_sort(ret_obj['data'])
-        sorted_json_data = ibmsecurity.utilities.tools.json_sort(json_data)
+        sorted_ret_obj = tools.json_sort(ret_obj['data'])
+        sorted_json_data = tools.json_sort(json_data)
         logger.debug("Sorted Existing Data:{0}".format(sorted_ret_obj))
         logger.debug("Sorted Desired  Data:{0}".format(sorted_json_data))
         if sorted_ret_obj != sorted_json_data:
@@ -137,7 +141,7 @@ def update(isamAppliance, name, connection, description='', locked=False, new_na
     return isamAppliance.create_return_object(warnings=warnings)
 
 
-def set(isamAppliance, name, connection, description='', locked=False, new_name=None, check_mode=False, force=False):
+def set(isamAppliance, name, connection, description='', locked=False, new_name=None, ignore_password_for_idempotency=False, check_mode=False, force=False):
     """
     Creating or Modifying a Web Service connection
     """
@@ -148,7 +152,7 @@ def set(isamAppliance, name, connection, description='', locked=False, new_name=
     else:
         # Update request
         return update(isamAppliance=isamAppliance, name=name, connection=connection, description=description,
-                      locked=locked, new_name=new_name, check_mode=check_mode, force=force)
+                      locked=locked, new_name=new_name, ignore_password_for_idempotency=ignore_password_for_idempotency, check_mode=check_mode, force=force)
 
 
 def _create_json(name, description, locked, connection):


### PR DESCRIPTION
- Adding idempotency check with seperate variable ignore_password_for_idempotency for set and update functions per connection type: ci, isamruntime, jdbc, ldap, smtp, ws
- BugFix: server_connections missing federation as requires_modules and/or requires_version parameter (ci.py, jdbc.py, ldap.py,smtp.py)