### PR TITLE
Ensure correct UTF-8 handling

### DIFF
--- a/ibmsecurity/appliance/isamappliance.py
+++ b/ibmsecurity/appliance/isamappliance.py
@@ -91,7 +91,7 @@ class ISAMAppliance(IBMAppliance):
         if http_response.text == "":
             json_data = {}
         else:
-            json_data = json.loads(http_response.text)
+            json_data = json.loads(http_response.content.decode("utf-8"))
 
         return_obj['data'] = json_data
 


### PR DESCRIPTION
When stored the the return_obj['data'] no utf-8 encoding of the returned data is done. This leads to encoding issues.  Updated to UTF-8 encoding as it is done in line 88 and 77.