### PR TITLE
BugFix+Feature: SCIM configuration

### DIFF
--- a/ibmsecurity/isam/aac/scim.py
+++ b/ibmsecurity/isam/aac/scim.py
@@ -1,4 +1,5 @@
 import logging
+import json
 from ibmsecurity.utilities import tools
 
 logger = logging.getLogger(__name__)
@@ -74,6 +75,11 @@ def set_all(isamAppliance, scim_configuration, check_mode=False, force=False):
         return isamAppliance.create_return_object(
             warnings="Need to pass content for scim configuration")
     else:
+        # Feature: Converting python string to dict (if required)
+        # Attention: JSON strings must use " quotes according to RFC 8259
+        # Example: '{"a":1, "b": 2, "c": 3}'
+        if isinstance(scim_configuration, str):
+            scim_configuration = json.loads(scim_configuration)
         if force is True or _check(isamAppliance, scim_configuration) is False:
             if check_mode is True:
                 return isamAppliance.create_return_object(changed=True)
@@ -92,9 +98,13 @@ def _check(isamAppliance, scim_configuration):
     """
     ret_obj = get_all(isamAppliance)
     logger.debug("Comparing server scim configuration with desired configuration.")
-    cur_sorted_json = tools.json_sort(ret_obj['data'])
+    # Converting python ret_obj['data'] and scim_configuration from type dict to valid JSON (RFC 8259)
+    # e.g. converts python boolean 'True' -> to JSON literal lowercase value 'true'
+    cur_json_string = json.dumps(ret_obj['data']) 
+    cur_sorted_json = tools.json_sort(cur_json_string)
     logger.debug("Server JSON : {0}".format(cur_sorted_json))
-    given_sorted_json = tools.json_sort(scim_configuration)
+    given_json_string = json.dumps(scim_configuration)
+    given_sorted_json = tools.json_sort(given_json_string)
     logger.debug("Desired JSON: {0}".format(given_sorted_json))
     if cur_sorted_json != given_sorted_json:
         return False


### PR DESCRIPTION
BugFix: _check function might fail on appliance return object from previous get_all with an TypeError: '<' not supported between instances of 'list' and 'tuple'

solution: Converting python ret_obj['data'] and scim_configuration from type dict to valid JSON (RFC 8259). e.g. converts python boolean 'True' -> to JSON literal lowercase value 'true'

Feature: Converting python string to dict (if required) on set_all function allowing strings and dicts to be passed in as function argument.