### PR TITLE
BugFix: Missing parameter 'signature_algorithm' on new CSR from 9.0.2.0 onwards

### DIFF
--- a/ibmsecurity/isam/base/ssl_certificates/certificate_requests.py
+++ b/ibmsecurity/isam/base/ssl_certificates/certificate_requests.py
@@ -1,5 +1,6 @@
 import logging
 import os.path
+import ibmsecurity.utilities.tools
 
 logger = logging.getLogger(__name__)
 
@@ -20,24 +21,42 @@ def get(isamAppliance, kdb_id, cert_id, check_mode=False, force=False):
                                     "/isam/ssl_certificates/{0}/cert_request/{1}".format(kdb_id, cert_id))
 
 
-def add(isamAppliance, kdb_id, label, dn, size='1024', check_mode=False, force=False):
+def add(isamAppliance, kdb_id, label, dn, size='1024', signature_algorithm='', check_mode=False, force=False):
     """
     Creating a certificate request in a certificate database
     """
+    
+    warnings = []
+    
+    if signature_algorithm is not None:
+        if ibmsecurity.utilities.tools.version_compare(isamAppliance.facts["version"], "9.0.2.0") < 0:
+            warnings.append("Appliance at version: {0}, signature_algorithm is not supported. Needs 9.0.2.0 or higher. "
+                            "Ignoring signature_algorithm for this call".format(isamAppliance.facts["version"]))
+            json_obj = {
+                    "label": label,
+                    "dn": dn,
+                    "size": size
+            }
+        else:
+            json_obj = {
+                    "label": label,
+                    "dn": dn,
+                    "size": size,
+                    "signature_algorithm": signature_algorithm
+            }
+    
     if force is True or _check(isamAppliance, kdb_id, label) is False:
         if check_mode is True:
             return isamAppliance.create_return_object(changed=True)
         else:
+            
             return isamAppliance.invoke_post(
                 "Creating a certificate request in a certificate database",
                 "/isam/ssl_certificates/{0}/cert_request".format(kdb_id),
-                {
-                    "label": label,
-                    "dn": dn,
-                    'size': size
-                })
+                json_obj,
+                warnings=warnings)
 
-    return isamAppliance.create_return_object()
+    return isamAppliance.create_return_object(changed=False, warnings=warnings)
 
 
 def delete(isamAppliance, kdb_id, cert_id, check_mode=False, force=False):


### PR DESCRIPTION
Adding missing signature_algorithm parameter to add function with appliance version checking (>9.0.2.0) for CSR request creation