### PR TITLE
Resolution to issue_303 (PoC)

### DIFF
--- a/ibmsecurity/isam/fed/point_of_contact.py
+++ b/ibmsecurity/isam/fed/point_of_contact.py
@@ -4,7 +4,7 @@ logger = logging.getLogger(__name__)
 
 # URI for this module
 uri = "/iam/access/v8/poc"
-requires_modules = ["federation"]
+requires_modules = ["federation", "mga"]
 requires_version = "9.0.1.0"
 
 


### PR DESCRIPTION
Add support for the Liberty Runtime PoC when just the 'fed' activation level is not installed.