### PR TITLE
optional Ignore error for pdadmin commands

### DIFF
--- a/ibmsecurity/appliance/isamappliance.py
+++ b/ibmsecurity/appliance/isamappliance.py
@@ -410,7 +410,7 @@ class ISAMAppliance(IBMAppliance):
                                         requires_model=requires_model, warnings=warnings)
         return response
 
-    def invoke_post(self, description, uri, data, ignore_error, requires_modules=None, requires_version=None,
+    def invoke_post(self, description, uri, data, ignore_error=False, requires_modules=None, requires_version=None,
                     warnings=[], requires_model=None):
         """
         Send a POST request to the LMI.

--- a/ibmsecurity/appliance/isamappliance.py
+++ b/ibmsecurity/appliance/isamappliance.py
@@ -410,7 +410,7 @@ class ISAMAppliance(IBMAppliance):
                                         requires_model=requires_model, warnings=warnings)
         return response
 
-    def invoke_post(self, description, uri, data, ignore_error=False, requires_modules=None, requires_version=None,
+    def invoke_post(self, description, uri, data, ignore_error, requires_modules=None, requires_version=None,
                     warnings=[], requires_model=None):
         """
         Send a POST request to the LMI.

--- a/ibmsecurity/isam/web/runtime/pdadmin.py
+++ b/ibmsecurity/isam/web/runtime/pdadmin.py
@@ -22,4 +22,5 @@ def execute(isamAppliance, isamUser, commands, ignore_error, admin_domain='Defau
                                          "admin_pwd": isamUser.password,
                                          "commands": commands,
                                          "admin_domain": admin_domain
-                                     })
+                                     },
+                                    ignore_error)

--- a/ibmsecurity/isam/web/runtime/pdadmin.py
+++ b/ibmsecurity/isam/web/runtime/pdadmin.py
@@ -8,7 +8,7 @@ except NameError:
 logger = logging.getLogger(__name__)
 
 
-def execute(isamAppliance, isamUser, commands, ignore_error, admin_domain='Default'):
+def execute(isamAppliance, isamUser, commands, ignore_error=False, admin_domain='Default'):
     """
     Execute a pdadmin command
     """

--- a/ibmsecurity/isam/web/runtime/pdadmin.py
+++ b/ibmsecurity/isam/web/runtime/pdadmin.py
@@ -8,7 +8,7 @@ except NameError:
 logger = logging.getLogger(__name__)
 
 
-def execute(isamAppliance, isamUser, commands, admin_domain='Default'):
+def execute(isamAppliance, isamUser, commands, admin_domain='Default', ignore_error):
     """
     Execute a pdadmin command
     """

--- a/ibmsecurity/isam/web/runtime/pdadmin.py
+++ b/ibmsecurity/isam/web/runtime/pdadmin.py
@@ -8,7 +8,7 @@ except NameError:
 logger = logging.getLogger(__name__)
 
 
-def execute(isamAppliance, isamUser, commands, admin_domain='Default', ignore_error):
+def execute(isamAppliance, isamUser, commands, ignore_error, admin_domain='Default'):
     """
     Execute a pdadmin command
     """


### PR DESCRIPTION
optionally ignore errors when running pdadmin commands. This allows for creating idempotent tasks in ansible using changed_when and error_when conditionals.