### PR TITLE
Check transform exists before deleting

### DIFF
--- a/ibmsecurity/isam/web/http_transformation.py
+++ b/ibmsecurity/isam/web/http_transformation.py
@@ -53,8 +53,10 @@ def delete(isamAppliance, id, check_mode=False, force=False):
     """
     Deleting a HTTP Transformation
     """
-    ret_obj_content = get(isamAppliance, id)
-    if ret_obj_content['data'] == {}:
+    #check if transformation exists before deleting
+    # use get_all and search result because get errors with 404 if transform doesn't exist
+    ret_obj_content = get_all(isamAppliance)
+    if not next((item for item in ret_obj_content['data'] if item["id"] == id), None):
         return isamAppliance.create_return_object(changed=False)
 
     if force is True or _check(isamAppliance, id) is True:

--- a/ibmsecurity/isam/web/http_transformation.py
+++ b/ibmsecurity/isam/web/http_transformation.py
@@ -53,6 +53,10 @@ def delete(isamAppliance, id, check_mode=False, force=False):
     """
     Deleting a HTTP Transformation
     """
+    ret_obj_content = get(isamAppliance, id)
+    if ret_obj_content['data'] == {}:
+        return isamAppliance.create_return_object(changed=False)
+
     if force is True or _check(isamAppliance, id) is True:
         if check_mode is True:
             return isamAppliance.create_return_object(changed=True)


### PR DESCRIPTION
check an http transformation exists before deleting. allows for graceful return from delete if transform doesn't exist instead of failure.