### PR TITLE
Feature: FIDO2 Configuration (inkl. administration) Support

### DIFF
--- a/ibmsecurity/isam/aac/fido2/metadata.py
+++ b/ibmsecurity/isam/aac/fido2/metadata.py
@@ -1,0 +1,177 @@
+import logging
+import json
+from ibmsecurity.utilities import tools
+
+logger = logging.getLogger(__name__)
+
+# URI for this module
+uri = "/iam/access/v8/fido2/metadata"
+requires_modules = ["mga"]
+requires_version = "9.0.7.0"
+
+def get_all(isamAppliance, check_mode=False, force=False):
+    """
+    Retrieve a list of FIDO2 Metadata
+    """
+    return isamAppliance.invoke_get("Retrieving the list of FIDO2 Metadata", uri,
+                                    requires_modules=requires_modules, requires_version=requires_version)
+
+def get(isamAppliance, name, id=None, check_mode=False, force=False):
+    """
+    Retrieve a specific FIDO2 Metadata
+    """
+    if id is None:
+        ret_obj = search(isamAppliance, name=name, check_mode=check_mode, force=force)
+        id = ret_obj['data']
+
+    if id == {}:
+        logger.info("FIDO2 Metadata {0} had no match, skipping retrieval.".format(name))
+        return isamAppliance.create_return_object()
+    else:
+        return _get(isamAppliance, id)
+
+def search(isamAppliance, name, force=False, check_mode=False):
+    """
+    Search FIDO2 Metadata id by name
+    """
+    ret_obj = get_all(isamAppliance)
+    return_obj = isamAppliance.create_return_object()
+
+    for obj in ret_obj['data']:
+        if obj['filename'] == name:
+            logger.info("Found FIDO2 Metadata {0} id: {1}".format(name, obj['id']))
+            return_obj['data'] = obj['id']
+            return_obj['rc'] = 0
+
+    return return_obj
+
+def delete(isamAppliance, name, check_mode=False, force=False):
+    """
+    Delete a FIDO2 Metadata file
+    """
+    ret_obj = search(isamAppliance, name, check_mode=check_mode, force=force)
+    id = ret_obj['data']
+
+    if id == {}:
+        logger.info("FIDO2 Metadata {0} not found, skipping delete.".format(name))
+    else:
+        if check_mode is True:
+            return isamAppliance.create_return_object(changed=True)
+        else:
+            return isamAppliance.invoke_delete(
+                "Delete a FIDO2 Metadata file",
+                "{0}/{1}".format(uri, id),
+                requires_modules=requires_modules, requires_version=requires_version)
+
+    return isamAppliance.create_return_object()
+
+def export_file(isamAppliance, name, filename, check_mode=False, force=False):
+    """
+    Export a specific FIDO2 Metadata file
+    """
+    import os.path
+    ret_obj = search(isamAppliance, name, check_mode=check_mode, force=force)
+    id = ret_obj['data']
+
+    if id == {}:
+        logger.info("FIDO2 Metadata {0} not found, skipping export.".format(name))
+    else:
+        if force is True or (os.path.exists(filename) is False):
+            if check_mode is False:  # No point downloading a file if in check_mode
+                return isamAppliance.invoke_get_file(
+                    "Export a specific FIDO2 Metadata file",
+                    "{0}/{1}/file".format(uri,id),
+                    filename,
+                    requires_modules=requires_modules, requires_version=requires_version)
+
+    return isamAppliance.create_return_object()
+
+def import_file(isamAppliance, filename, check_mode=False, force=False):
+    """
+    Import a new FIDO2 Metadata file or Import FIDO2 Metadata file contents to existing
+
+    Only a valid FIDO MDS Document (extension .json), Yubico Metadata (extension .yubico), or PEM Certificate (extension .pem) will be accepted.
+    Any other file type will fail validation.
+    """
+    import_new = False
+    update_required = False
+    if force is False:
+        ret_obj = search(isamAppliance, _extract_filename(filename))
+        if ret_obj['data'] != {}:
+            ret_obj_content = _get(isamAppliance, ret_obj['data'])
+            with open(filename, 'r') as infile:
+                content = infile.read()
+            if (ret_obj_content['data']['contents']).strip() != content.strip():
+                update_required = True
+        else:
+            import_new = True
+
+    if force is True or update_required is True or import_new is True:
+        if check_mode is True:
+            return isamAppliance.create_return_object(changed=True)
+        else:
+            if import_new is True:
+                filebasename = _extract_filename(filename)
+                return isamAppliance.invoke_post_files(
+                "Import a new FIDO2 Metadata file",
+                "{0}".format(uri),
+                [
+                    {
+                        'file_formfield': 'file',
+                        'filename': filename,
+                        'mimetype': 'application/file'
+                    }
+                ],
+                {
+                    "name": filebasename,
+                    "filename": filebasename
+                },
+                requires_modules=requires_modules, requires_version=requires_version)
+            else:
+                return isamAppliance.invoke_post_files(
+                    "Import a FIDO2 Metadata file (replace)",
+                    "{0}/{1}/file".format(uri,ret_obj['data']),
+                    [
+                        {
+                            'file_formfield': 'file',
+                            'filename': filename,
+                            'mimetype': 'application/file'
+                        }
+                    ],
+                    {},
+                    requires_modules=requires_modules, requires_version=requires_version)
+
+    return isamAppliance.create_return_object()
+
+def _get(isamAppliance, id):
+    return isamAppliance.invoke_get("Retrieve a specific FIDO2 Metadata by id",
+                                    f"{uri}/{id}",
+                                    requires_modules=requires_modules, requires_version=requires_version)
+
+def _extract_filename(upload_filename):
+    """
+    Extract filename from fully qualified path to use if no filename provided
+    """
+    import os.path
+    return os.path.basename(upload_filename)
+
+def _check(isamAppliance, fido2_metadata):
+    """
+    Check if FIDO2 metadata configuration is identical with server
+    """
+    ret_obj = get_all(isamAppliance)
+    logger.debug("Comparing server FIDO2 metadata configuration with desired configuration.")
+    # Converting python ret_obj['data'] dict to valid JSON (RFC 8259)
+    # e.g. converts python boolean 'True' -> to JSON literal lowercase value 'true'
+    cur_json_string = json.dumps(ret_obj['data']) 
+    cur_sorted_json = tools.json_sort(cur_json_string)
+    logger.debug("Server JSON : {0}".format(cur_sorted_json))
+    given_json_string = json.dumps(fido2_metadata)
+    given_sorted_json = tools.json_sort(given_json_string)
+    logger.debug("Desired JSON: {0}".format(given_sorted_json))
+    if cur_sorted_json != given_sorted_json:
+        return False
+        logger.debug("Changes detected!")
+    else:
+        logger.debug("Server configuration is identical with desired configuration. No change necessary.")
+        return True

--- a/ibmsecurity/isam/aac/fido2/registrations.py
+++ b/ibmsecurity/isam/aac/fido2/registrations.py
@@ -1,0 +1,52 @@
+import logging
+import json
+from ibmsecurity.utilities import tools
+
+logger = logging.getLogger(__name__)
+
+# URI for this module
+uri = "/iam/access/v8/fido2/registrations"
+requires_modules = ["mga"]
+requires_version = "9.0.7.0"
+
+def get_all(isamAppliance, check_mode=False, force=False):
+    """
+    Retrieve a list of all FIDO2 registrations
+    """
+    return isamAppliance.invoke_get("Retrieve a list of all FIDO2 registrations", uri,
+                                    requires_modules=requires_modules, requires_version=requires_version)
+
+def get(isamAppliance, credentialId, check_mode=False, force=False):
+    """
+    Retrieve a specific FIDO2 registration
+    """
+    ret_obj = isamAppliance.invoke_get("Retrieve a specific FIDO2 registration by credentialId",
+                                    f"{uri}/{credentialId}", ignore_error=True,
+                                    requires_modules=requires_modules, requires_version=requires_version)
+
+    if ret_obj['rc'] == 404:
+        logger.info("FIDO2 registration for {0} had no match.".format(credentialId))
+        return isamAppliance.create_return_object()
+    return ret_obj
+
+def delete(isamAppliance, username=None, credentialId=None, check_mode=False, force=False):
+    """
+    Delete all or specific FIDO2 registrations for a user
+    """
+    if username is None and credentialId is None:
+        from ibmsecurity.appliance.ibmappliance import IBMError
+        raise IBMError("999", "Cannot delete FIDO2 registration for unknown username or credentialID. Provide one of the required parameters.")
+
+    if check_mode is True:
+        return isamAppliance.create_return_object(changed=True)
+    else:
+        if username is not None:
+            return isamAppliance.invoke_delete(
+                "Delete all FIDO2 registrations for a user",
+                "{0}/username/{1}".format(uri, username),
+                requires_modules=requires_modules, requires_version=requires_version)
+        elif credentialId is not None:
+            return isamAppliance.invoke_delete(
+                "Delete a specific FIDO2 registration for a user",
+                "{0}/credentialId/{1}".format(uri, credentialId),
+                requires_modules=requires_modules, requires_version=requires_version)

--- a/ibmsecurity/isam/aac/fido2/relying_parties.py
+++ b/ibmsecurity/isam/aac/fido2/relying_parties.py
@@ -1,0 +1,181 @@
+import logging
+import json
+from ibmsecurity.utilities import tools
+
+logger = logging.getLogger(__name__)
+
+# URI for this module
+uri = "/iam/access/v8/fido2/relying-parties"
+requires_modules = ["mga"]
+requires_version = "9.0.7.0"
+
+def get_all(isamAppliance, check_mode=False, force=False):
+    """
+    Retrieve a list of all FIDO2 Relying Part
+    """
+    return isamAppliance.invoke_get("Retrieving the list of all FIDO2 Relying Parties", uri,
+                                    requires_modules=requires_modules, requires_version=requires_version)
+
+def get(isamAppliance, name, id=None, check_mode=False, force=False):
+    """
+    Retrieve a specific FIDO2 Relying Party
+    """
+    if id is None:
+        ret_obj = search(isamAppliance, name=name, check_mode=check_mode, force=force)
+        id = ret_obj['data']
+
+    if id == {}:
+        logger.info("FIDO2 Metadata {0} had no match, skipping retrieval.".format(name))
+        return isamAppliance.create_return_object()
+    else:
+        return _get(isamAppliance, id)
+
+def search(isamAppliance, name, force=False, check_mode=False):
+    """
+    Search FIDO2 Relying Party id by name
+    """
+    ret_obj = get_all(isamAppliance)
+    return_obj = isamAppliance.create_return_object()
+
+    for obj in ret_obj['data']:
+        if obj['name'] == name:
+            logger.info("Found FIDO2 relying party {0} id: {1}".format(name, obj['id']))
+            return_obj['data'] = obj['id']
+            return_obj['rc'] = 0
+
+    return return_obj
+
+def delete(isamAppliance, name, check_mode=False, force=False):
+    """
+    Delete a FIDO2 Relying Party
+    """
+    ret_obj = search(isamAppliance, name, check_mode=check_mode, force=force)
+    id = ret_obj['data']
+
+    if id == {}:
+        logger.info("FIDO2 relying party {0} not found, skipping delete.".format(name))
+    else:
+        if check_mode is True:
+            return isamAppliance.create_return_object(changed=True)
+        else:
+            return isamAppliance.invoke_delete(
+                "Delete a FIDO2 relying party",
+                "{0}/{1}".format(uri, id),
+                requires_modules=requires_modules, requires_version=requires_version)
+
+    return isamAppliance.create_return_object()
+
+def set(isamAppliance, name, rpId, fidoServerOptions, relyingPartyOptions, check_mode=False, force=False):
+    """
+    Create or Update a FIDO2 Relying Party
+    """
+    if (search(isamAppliance, name=name))['data'] == {}:
+        # Force the add - we already know FIDO2 Relying Party does not exist
+        logger.info("FIDO2 relying party {0} had no match, requesting to add new one.".format(name))
+        return add(isamAppliance, name=name, rpId=rpId, fidoServerOptions=fidoServerOptions, relyingPartyOptions=relyingPartyOptions,
+                   check_mode=check_mode, force=True)
+    else:
+        # Update request
+        logger.info("FIDO2 relying party {0} exists, requesting to update.".format(name))
+        return update(isamAppliance, name=name, rpId=rpId, fidoServerOptions=fidoServerOptions, relyingPartyOptions=relyingPartyOptions,
+                      check_mode=check_mode, force=force)
+
+def add(isamAppliance, name, rpId, fidoServerOptions, relyingPartyOptions, check_mode=False, force=False):
+    """
+    Create a new FIDO2 Relying Party
+    """
+    if force is False:
+        ret_obj = search(isamAppliance, name)
+    if force is True or ret_obj['data'] == {}:
+        if check_mode is True:
+            return isamAppliance.create_return_object(changed=True)
+        else:
+            return isamAppliance.invoke_post(
+                "Create a new FIDO2 relying party", uri,
+                {
+                    "name": name,
+                    "rpId": rpId,
+                    "fidoServerOptions": fidoServerOptions,
+                    "relyingPartyOptions": relyingPartyOptions
+                }, requires_modules=requires_modules, requires_version=requires_version)
+
+    return isamAppliance.create_return_object()
+
+def update(isamAppliance, name, rpId, fidoServerOptions, relyingPartyOptions, check_mode=False, force=False):
+    """
+    Update a specific FIDO2 Relying Party
+    """
+    rp_id, update_required, json_data = _check(isamAppliance, name=name, rpId=rpId, fidoServerOptions=fidoServerOptions, relyingPartyOptions=relyingPartyOptions)
+    if rp_id is None:
+        from ibmsecurity.appliance.ibmappliance import IBMError
+        raise IBMError("999", "Cannot update data for unknown FIDO2 relying party: {0}".format(name))
+
+    if force is True or update_required is True:
+        if check_mode is True:
+            return isamAppliance.create_return_object(changed=True)
+        else:
+            return isamAppliance.invoke_put(
+                "Update a specific FIDO2 relying party",
+                "{0}/{1}".format(uri, rp_id), json_data,
+                requires_modules=requires_modules,
+                requires_version=requires_version)
+
+    return isamAppliance.create_return_object()
+
+def _get(isamAppliance, id):
+    return isamAppliance.invoke_get("Retrieve a specific FIDO2 relying party by id",
+                                    f"{uri}/{id}")
+
+def _extract_filename(upload_filename):
+    """
+    Extract filename from fully qualified path to use if no filename provided
+    """
+    import os.path
+    return os.path.basename(upload_filename)
+
+def _check(isamAppliance, name, rpId, fidoServerOptions, relyingPartyOptions):
+    """
+    Check and return True if update needed
+
+    :param isamAppliance:
+    :param name:
+    :param rpId:
+    :param fidoServerOptions:
+    :param relyingPartyOptions:
+    :return:
+    """
+    update_required = False
+    json_data = {}
+    ret_obj = get(isamAppliance, name)
+    if ret_obj['data'] == {}:
+        logger.info("FIDO2 relying party not found, returning no update required.")
+        return None, update_required, json_data
+    else:
+        rp_id = ret_obj['data']['id']
+
+        if name is not None:
+            json_data["name"] = name
+
+        if rpId is not None:
+            json_data["rpId"] = rpId
+
+        if fidoServerOptions is not None:
+            json_data["fidoServerOptions"] = fidoServerOptions
+
+        if relyingPartyOptions is not None:
+            json_data["relyingPartyOptions"] = relyingPartyOptions
+
+        # Remove id as this is server specific dynamic data. Not required for configuration comparison
+        del ret_obj['data']['id']
+
+        import ibmsecurity.utilities.tools
+        sorted_json_data = ibmsecurity.utilities.tools.json_sort(json_data)
+        logger.debug("Sorted input: {0}".format(sorted_json_data))
+        sorted_ret_obj = ibmsecurity.utilities.tools.json_sort(ret_obj['data'])
+        logger.debug("Sorted existing data: {0}".format(sorted_ret_obj))
+        if sorted_ret_obj != sorted_json_data:
+            logger.info("Changes detected, update needed.")
+            update_required = True
+        else:
+            logger.info("No Changes detected, update NOT required.")
+    return rp_id, update_required, json_data

--- a/ibmsecurity/isam/aac/fido2/u2f_migration.py
+++ b/ibmsecurity/isam/aac/fido2/u2f_migration.py
@@ -1,0 +1,32 @@
+import logging
+import json
+from ibmsecurity.utilities import tools
+
+logger = logging.getLogger(__name__)
+
+# URI for this module
+uri = "/iam/access/v8/fido2/u2f-migration"
+requires_modules = ["mga"]
+requires_version = "9.0.7.0"
+
+def get_all(isamAppliance, check_mode=False, force=False):
+    """
+    Retrieve a count of U2F Registrations yet to be migrated
+    """
+    return isamAppliance.invoke_get("Retrieve a count of U2F Registrations yet to be migrated", uri,
+                                    requires_modules=requires_modules, requires_version=requires_version)
+
+def migrate(isamAppliance, batchSize, batchCount, check_mode=False, force=False):
+    """
+    Migrate U2F Registrations
+    """
+
+    json_data = {
+        "batchSize": batchSize,
+        "batchCount": batchCount
+    }
+
+    ret_obj = isamAppliance.invoke_post("Migrate U2F Registrations", uri, json_data,
+                                    requires_modules=requires_modules, requires_version=requires_version)
+
+    return ret_obj


### PR DESCRIPTION
New ISVA v9.0.7.0 FIDO2 Support added to ibmsecurity automation library

Following Testing was done via testisam.py:

```
[...]
# Configure FIDO
    p(ibmsecurity.isam.aac.fido2.metadata.get_all(isamAppliance=isam_server))
    p(ibmsecurity.isam.aac.fido2.metadata.get(isamAppliance=isam_server, name="metadata.json"))
    p(ibmsecurity.isam.aac.fido2.metadata.export_file(isamAppliance=isam_server, name="metadata.json", filename="metadata.json"))
    p(ibmsecurity.isam.aac.fido2.metadata.delete(isamAppliance=isam_server, name="metadata.json"))
    p(ibmsecurity.isam.aac.fido2.metadata.import_file(isamAppliance=isam_server, filename="metadata.json"))

    p(ibmsecurity.isam.aac.fido2.relying_parties.get_all(isamAppliance=isam_server))
    p(ibmsecurity.isam.aac.fido2.relying_parties.get(isamAppliance=isam_server, name="DEMO"))
    p(ibmsecurity.isam.aac.fido2.relying_parties.add(isamAppliance=isam_server, name="DEMO", rpId="example.com", relyingPartyOptions={'impersonationGroup':'adminGroup','webauthnSpecEnforcement':True}, fidoServerOptions={'origins':['https://example.com'],'metadataSet':[],'metadataSoftFail':True,'attestation':{'statementTypes':['basic','self','attCA','none'],'statementFormats':['fido-u2f','packed','tpm','android-key','android-safetynet','none'],'publicKeyAlgorithms':['SHA256withECDSA','SHA256withRSA']},'android-safetynet':{'attestationMaxAge':60000,'clockSkew':30000}}))
    p(ibmsecurity.isam.aac.fido2.relying_parties.set(isamAppliance=isam_server, name="DEMO", rpId="example.com", relyingPartyOptions={'impersonationGroup':'adminGroup','webauthnSpecEnforcement':True}, fidoServerOptions={'origins':['https://example.com'],'metadataSet':[],'metadataSoftFail':True,'attestation':{'statementTypes':['basic','self','attCA','none'],'statementFormats':['fido-u2f','packed','tpm','android-key','android-safetynet','none'],'publicKeyAlgorithms':['SHA256withECDSA','SHA256withRSA']},'android-safetynet':{'attestationMaxAge':60000,'clockSkew':30000}}))

    p(ibmsecurity.isam.aac.fido2.registrations.get_all(isamAppliance=isam_server))
    p(ibmsecurity.isam.aac.fido2.registrations.get(isamAppliance=isam_server, credentialId="CKYuA1IJW4wY-FnKY_gLubEfaqEJK6_6E4t8I_JWgmE"))
    p(ibmsecurity.isam.aac.fido2.registrations.delete(isamAppliance=isam_server, username="testuser01"))

    p(ibmsecurity.isam.aac.fido2.u2f_migration.get_all(isamAppliance=isam_server))
    p(ibmsecurity.isam.aac.fido2.u2f_migration.migrate(isamAppliance=isam_server, batchSize='1000', batchCount='all'))
[...]
```