### PR TITLE
Issue340 reverseproxy config idempotency

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ has the most mature code, code for ISDS appliance is being developed.
 
 ## Requirements
 
-Python v2.7.10 and above is required for this package. The package also supports python3 simultaneously (recommend v3.7 or higher).
+Python v3.7 and above is required for this package. Python v2.7.10 may still work.
 
 The following Python Packages are required:
 1. requests - for making REST API calls

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # IBM Sample Code
 
 This repository contains Python code to manage IBM Security Appliances using their respective REST APIs. ISAM appliance
-has the most mature code, code for ISDS appliance is being developed.
+has the most mature code, code for ISDS appliance is under development.
 
 ## Requirements
 
@@ -29,7 +29,7 @@ This python package provides the following features:
 2. Intuitive layout of code package and naming maps to the GUI interface of appliance
 3. Idempotency - functions that make updates will query the appliance to compare given data to see if a 
 changes is required before making the actual change.
-4. Commit and Deploy steps are provided separately to allow for flexilibity in invoking them
+4. Commit and Deploy steps are provided separately to allow for flexibility in invoking them
 5. Standard logging is included - with the ability to set logging levels.
 6. Parameters to function will use standard default values wherever possible.
 7. A force option is provided to override idempotency.
@@ -97,7 +97,7 @@ This function returns the details of one particular object.
 ### `set()`
 This function will determine if the object to be manipulated exists, if not then it calls add() otherwise it will call update().
 In cases where there is no update() then it will compare to see if there is a difference between existing value on the appliance
-to that being set via the function - if different then it delete()'s the object before calling add().
+to that being set via the function - if different then it `delete()`'s the object before calling add().
 ### `add()`
 Check and see if the object already exists - if so then skip, otherwise add it.
 ### `update()`

--- a/ibmsecurity/utilities/tools.py
+++ b/ibmsecurity/utilities/tools.py
@@ -8,6 +8,7 @@ import ntpath
 import re
 from io import open
 import zipfile
+import json
 
 logger = logging.getLogger(__name__)
 
@@ -25,6 +26,17 @@ def json_sort(json_data):
         return sorted(json_sort(x) for x in json_data)
     else:
         return json_data
+
+class jsonSortedListEncoder(json.JSONEncoder):
+   def encode(self, obj):
+       def sort_lists(item):
+           if isinstance(item, list):
+               return sorted(sort_lists(i) for i in item)
+           elif isinstance(item, dict):
+               return {k: sort_lists(v) for k, v in item.items()}
+           else:
+               return item
+       return super(SortedListEncoder, self).encode(sort_lists(obj))
 
 
 def json_replace_value(json_data, from_value, to_value):

--- a/ibmsecurity/utilities/tools.py
+++ b/ibmsecurity/utilities/tools.py
@@ -27,7 +27,12 @@ def json_sort(json_data):
     else:
         return json_data
 
+
 class jsonSortedListEncoder(json.JSONEncoder):
+   """
+   This is a custom class for use with json.dumps
+   https://docs.python.org/3/library/json.html
+   """
    def encode(self, obj):
        def sort_lists(item):
            if isinstance(item, list):
@@ -36,7 +41,7 @@ class jsonSortedListEncoder(json.JSONEncoder):
                return {k: sort_lists(v) for k, v in item.items()}
            else:
                return item
-       return super(SortedListEncoder, self).encode(sort_lists(obj))
+       return super(jsonSortedListEncoder, self).encode(sort_lists(obj))
 
 
 def json_replace_value(json_data, from_value, to_value):


### PR DESCRIPTION
This code improves idempotency for editing entries.  It closes #340.

This is only applicable for the `entries` style of writing, where you can update multiple entries at once. 
The code also does a more efficient check, by doing a single call per stanza instead of a call per entry (get_all instead of get).
That, however, does not make a noticable difference in performance. 

That idempotency now works better, obvioulsy does make a huge difference in performance (when there are no changes), though.
 
These tests need to run twice, to demonstrate idempotency.  If you run these with the current code, you'll see the idempotency check fails.

```
p(ibmsecurity.isam.web.reverse_proxy.configuration.entry.set(isamAppliance=isam_server,
                                                                                 reverseproxy_id="default",
                                                                                 stanza_id="filter-content-types",
                                                                                 entries=[["type", "text/html"],
                                                                                          ["type", "text/vnd.wap.wml"],
                                                                                          ["type",
                                                                                           "applications/atom+xml"]]))

    p(ibmsecurity.isam.web.reverse_proxy.configuration.entry.set(isamAppliance=isam_server,
                                                                                 reverseproxy_id="default",
                                                                                 stanza_id="server",
                                                                                 entries=[
                                                                                     ["use-http-only-cookies", "yes"],
                                                                                     ["allow-unsollicited-logins",
                                                                                      "no"],
                                                                                     ["worker-threads", "1000"],
                                                                                     ["suppress-server-identity", "yes"]
                                                                                     ]))

    p(ibmsecurity.isam.web.reverse_proxy.configuration.entry.set(isamAppliance=isam_server,
                                                                                 reverseproxy_id="default",
                                                                                 stanza_id="session",
                                                                                 entries=[
                                                                                     ["create-unauth-sessions", "yes"],
                                                                                     ["inactive-timeout", 1800],
                                                                                     ["max-entries", 8192],
                                                                                     ["ssl-id-sessions", "no"],
                                                                                     ["timeout", 21600],
                                                                                     ["unauth-inactive-timeout", 300],
                                                                                     ["unauth-max-entries", 4096]
                                                                                     ]))
    # Commit or Deploy the changes
    p(ibmsecurity.isam.appliance.commit(isamAppliance=isam_server))
```

I've also updated the readme to be in line with what is mentioned in the ibm.isam Ansible Collection.