### PR TITLE
Issue341 certificate idempotency

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,13 @@ The following Python Packages are required:
 2. importlib - for the sample code to work
 3. PyYAML - for the sample code to work
 
+The following Python Packages are optional:
+1. pyOpenSSL - to perform action on certificates (used for idempotency in management_ssl_certificate)
+2. python-dateutil - date utilities (used for idempotency in management_ssl_certificate)
+
 Appliances need to have an ip address defined for their LMI. This may mean that appliances have had their initial setup 
 done with license acceptance.
+
 
 ## Versioning
 

--- a/ibmsecurity/isam/base/management_ssl_certificate.py
+++ b/ibmsecurity/isam/base/management_ssl_certificate.py
@@ -1,8 +1,18 @@
 import logging
 import ibmsecurity.utilities.tools
+from datetime import datetime
+import json
+
+performCertCheck = True
+try:
+    from dateutil import parser
+    #pip install python-dateutil
+    from OpenSSL.crypto import load_pkcs12, dump_certificate, load_certificate, FILETYPE_PEM
+    # pip install pyOpenSSL
+except:
+    performCertCheck = False
 
 logger = logging.getLogger(__name__)
-
 
 def get(isamAppliance, check_mode=False, force=False):
     """
@@ -16,8 +26,11 @@ def set(isamAppliance, certificate, password, check_mode=False, force=False):
     """
     Import certificate database
     """
-    warnings = ["Idempotency not available. Unable to extract existing certificate to compare with provided one."]
-    if force is True or _check(isamAppliance, certificate, password) is False:
+    if not performCertCheck:
+        warnings = ["Idempotency not available. Unable to extract existing certificate to compare with provided one.  Install Python modules python-dateutil and pyOpenSSL."]
+    else:
+        warnings = None
+    if force is True or not _check(isamAppliance, certificate, password):
         if check_mode is True:
             return isamAppliance.create_return_object(changed=True, warnings=warnings)
         else:
@@ -41,11 +54,51 @@ def set(isamAppliance, certificate, password, check_mode=False, force=False):
 
 def _check(isamAppliance, certificate, password):
     """
-    TODO replace placeholder
     requires additionally pyOpenSSL to load the p12 and extract the issuer, subject, etc
+    Comparing issuer, subject, notafter (date only) and notbefore (date only)
+    This DOES NOT check if the certificate is newer , just that it's different from the one that is deployed.
     """
+    if performCertCheck:
+        currentCert = get(isamAppliance)
+        currentCert = currentCert['data']
 
-    return False
+        # remove values that are not checked
+        del currentCert['keysize']
+        del currentCert['version']
+
+        # use date only to compare.  this simplifies the logic here, Python is not very strong with comparing dates in different timezones
+        currentCert['notbefore'] = parser.parse(currentCert['notbefore'], ignoretz=True).strftime("%Y-%m-%d")
+        currentCert['notafter'] = parser.parse(currentCert['notafter'], ignoretz=True).strftime("%Y-%m-%d")
+
+        newCert = {}
+        _type = FILETYPE_PEM
+        _enc = 'utf-8'
+        with open(certificate, 'rb') as f:
+            c = f.read()
+        p = load_pkcs12(c, password)
+
+        certificate = p.get_certificate()
+        newCert['subject'] = ",".join(f"{str(name, 'utf-8')}={str(value, 'utf-8')}" for name, value in reversed(certificate.get_subject().get_components()))
+
+        x509 = load_certificate(_type, dump_certificate(_type, certificate))
+
+        newCert['issuer'] = ",".join(f"{str(name, _enc)}={str(value, _enc)}" for name, value in reversed(x509.get_issuer().get_components()))
+        newCert['notafter'] = datetime.strptime(str(x509.get_notAfter(), _enc), "%Y%m%d%H%M%SZ").strftime("%Y-%m-%d")
+        newCert['notbefore'] = datetime.strptime(str(x509.get_notBefore(), _enc), "%Y%m%d%H%M%SZ").strftime("%Y-%m-%d")
+
+        curc = json.dumps(currentCert, skipkeys=True, sort_keys=True)
+        logger.debug(f"\nSorted Current  Management Cert:\n {curc}\n")
+
+        newc = json.dumps(newCert, skipkeys=True, sort_keys=True)
+        logger.debug(f"\nSorted Desired  Management Cert:\n {newc}\n")
+
+        if curc == newc:
+            return True
+        else:
+            return False
+    else:
+        logger.info('Skipping management certificate check because pyOpenSSL or not available.  Install with pip install pyOpenSSL')
+        return False
 
 
 def compare(isamAppliance1, isamAppliance2):


### PR DESCRIPTION
Closes #341 .

Adds a comparison between new management certificate and current.  
The comparison only takes the date into account (drops the time).
Python packages `pyOpenSSL` and `python-dateutil` are necessary to perform the _check, but if they are not available, the checks are simply passed (so back to current behaviour).

Test:
```
    #Prepare self signed cert
    #  openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:2048 -keyout privateKey.key -out certificate.crt -subj "/C=BE/O=IBM/OU=ISAM/CN=myisam.example.com
    #  openssl pkcs12 -info -in myisam.p12
    #  the password you assign should match the one in the call below:

    p(ibmsecurity.isam.base.management_ssl_certificate.set(isamAppliance=isam_server, certificate='myisam.p12', password='passw0rd'))
```