### PR TITLE
IBM Security Verify Governance 

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository contains Python code to manage IBM Security Appliances using their respective REST APIs.
 ISAM appliance has the most mature code.
 Code for ISDS appliance is under development.
-Code for ISVG appliance is brand new (tested with 10.0.1.0 and highier only).
+Code for ISVG appliance is brand new (tested with 10.0.1.0 and higher only).
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # IBM Sample Code
 
-This repository contains Python code to manage IBM Security Appliances using their respective REST APIs. ISAM appliance
-has the most mature code, code for ISDS appliance is under development.
+This repository contains Python code to manage IBM Security Appliances using their respective REST APIs.
+ISAM appliance has the most mature code.
+Code for ISDS appliance is under development.
+Code for ISVG appliance is brand new (tested with 10.0.1.0 and highier only).
 
 ## Requirements
 

--- a/ibmsecurity/appliance/isvgappliance.py
+++ b/ibmsecurity/appliance/isvgappliance.py
@@ -1,0 +1,411 @@
+import json
+import requests
+from requests.packages.urllib3.exceptions import InsecureRequestWarning
+import logging
+from .ibmappliance import IBMAppliance
+from .ibmappliance import IBMError
+from ibmsecurity.utilities import tools
+from io import open
+
+try:
+    basestring
+except NameError:
+
+    basestring = (str, bytes)
+
+
+class ISVGAppliance(IBMAppliance):
+    def __init__(self, hostname, user, lmi_port=443):
+        self.logger = logging.getLogger(__name__)
+        self.logger.debug('Creating an ISVGAppliance')
+        if isinstance(lmi_port, basestring):
+            self.lmi_port = int(lmi_port)
+        else:
+            self.lmi_port = lmi_port
+
+        IBMAppliance.__init__(self, hostname, user)
+
+    def _url(self, uri):
+        # Build up the URL
+        url = "https://" + self.hostname + ":" + str(self.lmi_port) + uri
+        self.logger.debug("Issuing request to: " + url)
+
+        return url
+
+    def _log_desc(self, description):
+        if description != "":
+            self.logger.info('*** ' + description + ' ***')
+
+    def _suppress_ssl_warning(self):
+        # Disable https warning because of non-standard certs on appliance
+        try:
+            self.logger.debug("Suppressing SSL Warnings.")
+            requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+        except AttributeError:
+            self.logger.warning("load requests.packages.urllib3.disable_warnings() failed")
+
+    def _process_response(self, return_obj, http_response, ignore_error):
+
+        return_obj['rc'] = http_response.status_code
+
+        # Examine the response.
+        if (http_response.status_code == 302):
+            self.logger.warning("  Endpoint cannot be use at this time: ")
+            self.logger.warning("     status code: {0}".format(http_response.status_code))
+            if http_response.text != "":
+                self.logger.error("     text: " + http_response.text)
+            # Too early to use this endppoint.
+            return_obj['changed'] = False
+            return_obj['rc'] = 0
+        elif (http_response.status_code != 200 and http_response.status_code != 204 and http_response.status_code != 201):
+            self.logger.error("  Request failed: ")
+            self.logger.error("     status code: {0}".format(http_response.status_code))
+            if http_response.text != "":
+                self.logger.error("     text: " + http_response.text)
+            if not ignore_error:
+                raise IBMError("HTTP Return code: {0}".format(http_response.status_code), http_response.text)
+            return_obj['changed'] = False  # force changed to be False as there is an error
+        else:
+            return_obj['rc'] = 0
+
+        # Handle if there was json on input but response was not in json format
+        try:
+            json_data = json.loads(http_response.text)
+        except ValueError:
+            return_obj['data'] = http_response.content
+            return
+
+        self.logger.debug("Status Code: {0}".format(http_response.status_code))
+        if http_response.text != "":
+            self.logger.debug("Text: " + http_response.content.decode("utf-8"))
+
+        for key in http_response.headers:
+            if key == 'g-type':
+                if http_response.headers[key] == 'application/octet-stream; charset=UTF-8':
+                    json_data = {}
+                    return_obj.data = http_response.content
+                    return
+
+        if http_response.text == "":
+            json_data = {}
+        else:
+            json_data = json.loads(http_response.text)
+
+        return_obj['data'] = json_data
+
+    def _process_connection_error(self, ignore_error, return_obj):
+        if not ignore_error:
+            self.logger.critical("Failed to connect to server.")
+            raise IBMError("HTTP Return code: 502", "Failed to connect to server")
+        else:
+            self.logger.debug("Failed to connect to server.")
+            return_obj['rc'] = 502
+
+    def _process_warnings(self, uri, requires_modules, requires_version, warnings=[]):
+        # flag to indicate if processing needs to return and not continue
+        return_call = False
+        self.logger.debug("Checking for minimum version: {0}.".format(requires_version))
+        if requires_version is not None and 'version' in self.facts and self.facts['version'] is not None:
+            if self.facts['version'] < requires_version:
+                return_call = True
+                warnings.append(
+                    "API invoked requires minimum version: {0}, appliance is of lower version: {1}.".format(
+                        requires_version, self.facts['version']))
+        # Detecting modules from uri if none is provided
+        if requires_modules is None and not requires_modules:
+            if uri.startswith("/wga"):
+                requires_modules = ['wga']
+                self.logger.debug("Detected module: {0} from uri: {1}.".format(requires_modules, uri))
+            elif uri.startswith("/mga"):
+                requires_modules = ['mga']
+                self.logger.debug("Detected module: {0} from uri: {1}.".format(requires_modules, uri))
+
+        self.logger.debug("Checking for one of required modules: {0}.".format(requires_modules))
+        if requires_modules is not None and requires_modules:
+            if 'activations' in self.facts and self.facts['activations']:
+                # Find intersection of the two lists
+                iactive = [ia for ia in self.facts['activations'] if ia in requires_modules]
+                if not iactive:
+                    return_call = True
+                    warnings.append(
+                        "API invoked requires one of modules: {0}, appliance has these modules active: {1}.".format(
+                            requires_modules, self.facts['activations']))
+                else:
+                    self.logger.info("Modules satisfying requirement: {0}".format(iactive))
+            else:
+                return_call = True
+                warnings.append("API invoked requires module: {0}, appliance has no modules active.".format(
+                    requires_modules))
+
+        self.logger.debug("Warnings: {0}".format(warnings))
+        return warnings, return_call
+
+    def invoke_post_files(self, description, uri, fileinfo, data, ignore_error=False, requires_modules=None,
+                          requires_version=None, warnings=[], json_response=True):
+        """
+        Send multipart/form-data upload file request to the appliance.
+        """
+        self._log_desc(description=description)
+
+        warnings, return_call = self._process_warnings(uri=uri, requires_modules=requires_modules,
+                                                       requires_version=requires_version,
+                                                       warnings=warnings)
+        return_obj = self.create_return_object(warnings=warnings)
+        if return_call:
+            return return_obj
+
+        # Build up the URL and header information.
+        if json_response:
+            headers = {
+                'Accept': 'application/json,text/html,application/xhtml+xml,application/xml'
+            }
+        else:
+            headers = {
+                'Accept': 'text/html,application/xhtml+xml,application/xml'
+            }
+        self.logger.debug("Headers are: {0}".format(headers))
+
+        files = list()
+        for file2post in fileinfo:
+            files.append((file2post['file_formfield'],
+                          (tools.path_leaf(file2post['filename']), open(file2post['filename'], 'rb'),
+                           file2post['mimetype'])))
+
+        self._suppress_ssl_warning()
+
+        try:
+            r = requests.post(url=self._url(uri=uri), data=data, auth=(self.user.username, self.user.password),
+                              files=files, verify=False, headers=headers)
+            return_obj['changed'] = True  # POST of file would be a change
+            self._process_response(return_obj=return_obj, http_response=r, ignore_error=ignore_error)
+
+        except requests.exceptions.ConnectionError:
+            if not ignore_error:
+                self.logger.critical("Failed to connect to server.")
+                raise IBMError("HTTP Return code: 502", "Failed to connect to server")
+            else:
+                self.logger.debug("Failed to connect to server.")
+                return_obj.rc = 502
+
+        return return_obj
+
+    def invoke_put_files(self, description, uri, fileinfo, data, ignore_error=False, requires_modules=None,
+                         requires_version=None, warnings=[]):
+        """
+        Send multipart/form-data upload file request to the appliance.
+        """
+        self._log_desc(description=description)
+
+        warnings, return_call = self._process_warnings(uri=uri, requires_modules=requires_modules,
+                                                       requires_version=requires_version,
+                                                       warnings=warnings)
+        return_obj = self.create_return_object(warnings=warnings)
+        if return_call:
+            return return_obj
+
+        # Build up the URL and header information.
+        headers = {
+            'Accept': 'application/json,text/html,application/xhtml+xml,application/xml'
+        }
+        self.logger.debug("Headers are: {0}".format(headers))
+
+        files = list()
+
+        for file2post in fileinfo:
+            files.append((file2post['file_formfield'],
+                          (file2post['filename'], open(file2post['filename'], 'rb'), file2post['mimetype'])))
+
+        self._suppress_ssl_warning()
+
+        try:
+            r = requests.put(url=self._url(uri=uri), data=data, auth=(self.user.username, self.user.password),
+                             files=files, verify=False, headers=headers)
+            return_obj['changed'] = True  # POST of file would be a change
+            self._process_response(return_obj=return_obj, http_response=r, ignore_error=ignore_error)
+
+        except requests.exceptions.ConnectionError:
+            if not ignore_error:
+                self.logger.critical("Failed to connect to server.")
+                raise IBMError("HTTP Return code: 502", "Failed to connect to server")
+            else:
+                self.logger.debug("Failed to connect to server.")
+                return_obj.rc = 502
+
+        return return_obj
+
+    def invoke_get_file(self, description, uri, filename, no_headers=False, mime_types=None, ignore_error=False, requires_modules=None,
+                        requires_version=None, warnings=[]):
+        """
+        Invoke a GET request and download the response data to a file
+        """
+        self._log_desc(description=description)
+
+        warnings, return_call = self._process_warnings(uri=uri, requires_modules=requires_modules,
+                                                       requires_version=requires_version,
+                                                       warnings=warnings)
+        return_obj = self.create_return_object(warnings=warnings)
+        if return_call:
+            return return_obj
+
+        # In some cases passing a header causes response to come back as JSON
+        if no_headers is True:
+            headers = {}
+        elif mime_types is None:
+            headers = {
+                'Accept': 'application/json,application/octet-stream'
+            }
+        else:
+            headers = {
+                'Accept': mime_types
+            }
+        self.logger.debug("Headers are: {0}".format(headers))
+
+        self._suppress_ssl_warning()
+
+        try:
+            r = requests.get(url=self._url(uri=uri), auth=(self.user.username, self.user.password), verify=False,
+                             stream=True, headers=headers, allow_redirects=False)
+
+            if (r.status_code != 200 and r.status_code != 204 and r.status_code != 201):
+                self.logger.error("  Request failed: ")
+                self.logger.error("     status code: {0}".format(r.status_code))
+                if r.text != "":
+                    self.logger.error("     text: " + r.text)
+                if not ignore_error:
+                    raise IBMError("HTTP Return code: {0}".format(r.status_code), r.text)
+                else:
+                    return_obj['rc'] = r.status_code
+                    return_obj['data'] = {'msg': 'Unable to extract contents to file!'}
+            else:
+                with open(filename, 'wb') as f:
+                    for chunk in r.iter_content(chunk_size=1024):
+                        if chunk:  # filter out keep-alive new chunks
+                            f.write(chunk)
+                return_obj['rc'] = 0
+                return_obj['data'] = {'msg': 'Contents extracted to file: ' + filename}
+
+        except requests.exceptions.ConnectionError:
+            self._process_connection_error(ignore_error=ignore_error, return_obj=return_obj)
+
+        except IOError:
+            if not ignore_error:
+                self.logger.critical("Failed to write to file: " + filename)
+                raise IBMError("HTTP Return code: 999", "Failed to write to file: " + filename)
+            else:
+                self.logger.debug("Failed to write to file: " + filename)
+                return_obj['rc'] = 999
+
+        return return_obj
+
+    def _invoke_request(self, func, description, uri, ignore_error, data={}, requires_modules=None,
+                        requires_version=None, warnings=[]):
+        """
+        Send a request to the LMI.  This function is private and should not be
+        used directly.  The invoke_get/invoke_put/etc functions should be used instead.
+        """
+        self._log_desc(description=description)
+
+        warnings, return_call = self._process_warnings(uri=uri, requires_modules=requires_modules,
+                                                       requires_version=requires_version,
+                                                       warnings=warnings)
+        return_obj = self.create_return_object(warnings=warnings)
+        if return_call:
+            return return_obj
+
+        # There maybe some cases when header should be blank (not json)
+        headers = {
+            'Accept': 'application/json',
+            'Content-type': 'application/json'
+        }
+        self.logger.debug("Headers are: {0}".format(headers))
+
+        # Process the input data into JSON
+        json_data = json.dumps(data)
+
+        self.logger.debug("Input Data: " + json_data)
+
+        self._suppress_ssl_warning()
+
+        try:
+            if func == requests.get or func == requests.delete:
+
+                if data != {}:
+                    r = func(url=self._url(uri), data=json_data, auth=(self.user.username, self.user.password),
+                             verify=False, headers=headers, allow_redirects=False)
+                else:
+                    r = func(url=self._url(uri), auth=(self.user.username, self.user.password),
+                             verify=False, headers=headers, allow_redirects=False)
+            else:
+                r = func(url=self._url(uri), data=json_data,
+                         auth=(self.user.username, self.user.password),
+                         verify=False, headers=headers)
+
+            if func != requests.get:
+                return_obj['changed'] = True  # Anything but GET should result in change
+
+            self._process_response(return_obj=return_obj, http_response=r, ignore_error=ignore_error)
+
+        except requests.exceptions.ConnectionError:
+            self._process_connection_error(ignore_error=ignore_error, return_obj=return_obj)
+
+        return return_obj
+
+    def invoke_put(self, description, uri, data, ignore_error=False, requires_modules=None, requires_version=None,
+                   warnings=[]):
+        """
+        Send a PUT request to the LMI.
+        """
+        return self._invoke_request(requests.put, description, uri, ignore_error, data,
+                                    requires_modules=requires_modules, requires_version=requires_version,
+                                    warnings=warnings)
+
+    def invoke_post(self, description, uri, data, ignore_error=False, requires_modules=None, requires_version=None,
+                    warnings=[]):
+        """
+        Send a POST request to the LMI.
+        """
+        return self._invoke_request(requests.post, description, uri, ignore_error, data,
+                                    requires_modules=requires_modules, requires_version=requires_version,
+                                    warnings=warnings)
+
+    def invoke_get(self, description, uri, ignore_error=False, requires_modules=None, requires_version=None,
+                   warnings=[]):
+        """
+        Send a GET request to the LMI.
+        """
+        return self._invoke_request(requests.get, description, uri, ignore_error, requires_modules=requires_modules,
+                                    requires_version=requires_version, warnings=warnings)
+
+    def invoke_delete(self, description, uri, ignore_error=False, requires_modules=None, requires_version=None,
+                      warnings=[]):
+        """
+        Send a DELETE request to the LMI.
+        """
+        return self._invoke_request(requests.delete, description, uri, ignore_error, requires_modules=requires_modules,
+                                    requires_version=requires_version, warnings=warnings)
+
+    def get_facts(self):
+        """
+        Get facts about the appliance
+        """
+        # Fact collection will abort on any exception
+        try:
+            self.get_version()
+        # Exceptions like those connection related will be ignored
+        except:
+            pass
+
+    def get_version(self):
+        """
+        Get  appliance version (active partition)
+
+        When firmware are installed or partition are changed, then this value is updated
+        """
+        self.facts['version'] = None
+        import ibmsecurity.isvg.firmware
+
+        ret_obj = ibmsecurity.isvg.firmware.get(self)
+        for partition in ret_obj['data']:
+            if partition['active'] is True:
+                ver = partition['firmware_version'].split(' ')
+                self.facts['version'] = ver[-1]

--- a/ibmsecurity/appliance/isvgappliance_adminproxy.py
+++ b/ibmsecurity/appliance/isvgappliance_adminproxy.py
@@ -1,0 +1,49 @@
+import json
+import requests
+from requests.packages.urllib3.exceptions import InsecureRequestWarning
+import logging
+from ibmsecurity.appliance.ibmappliance import IBMAppliance
+from ibmsecurity.appliance.isvgappliance import ISVGAppliance
+from ibmsecurity.appliance.ibmappliance import IBMError
+from ibmsecurity.utilities import tools
+
+try:
+    basestring
+except NameError:
+    basestring = (str, bytes)
+
+
+class ISVGApplianceAdminProxy(ISVGAppliance):
+    def __init__(self, adminProxyHostname, user, hostname, adminProxyProtocol='https', adminProxyPort=443,
+                 adminProxyApplianceShortName=False):
+        self.logger = logging.getLogger(__name__)
+        self.logger.debug('Creating an ISVGAppliance over AdminProxy')
+
+        self.adminProxyProtocol = adminProxyProtocol
+        self.adminProxyHostname = adminProxyHostname
+
+        # Type checking and tranformation to safely reuse this variable later on
+        if isinstance(adminProxyPort, basestring):
+            self.adminProxyPort = int(adminProxyPort)
+        else:
+            self.adminProxyPort = adminProxyPort
+
+        self.adminProxyApplianceShortName = adminProxyApplianceShortName
+
+        ISVGAppliance.__init__(self, hostname, user)
+
+    def _url(self, uri):
+        # shorten the junction name from hostname parameter
+        # e.g.  isvg.ibm.com -junction-> /isvg          (with short name)
+        #       isvg.ibm.com -junction-> /isvg.ibm.com  (without short name)
+        if self.adminProxyApplianceShortName:
+            applianceJunction = self.hostname.split('.')[0]
+        else:
+            applianceJunction = self.hostname
+
+        # Build up the URL
+        url = self.adminProxyProtocol + "://" + self.adminProxyHostname + ":" + str(
+            self.adminProxyPort) + "/" + applianceJunction + uri
+        self.logger.info("Issuing request to Appliance over AdminProxy: " + url)
+
+        return url

--- a/ibmsecurity/isvg/admin.py
+++ b/ibmsecurity/isvg/admin.py
@@ -1,0 +1,91 @@
+import logging
+import ibmsecurity.utilities.tools
+
+logger = logging.getLogger(__name__)
+
+
+def get(isvgAppliance, check_mode=False, force=False):
+    """
+    Retrieving the administrator settings
+    """
+    return isvgAppliance.invoke_get("Retrieving the administrator settings", "/admin_cfg")
+
+
+def set_pw(isvgAppliance, newPassword, oldPassword, sessionTimeout="30", check_mode=False, force=False):
+    """
+    Set password for admin user (super user for appliance)
+    """
+    warnings = ["Password change requested - cannot query existing password for idempotency check."]
+    if check_mode is True:
+        return isvgAppliance.create_return_object(changed=True, warnings=warnings)
+    else:
+        json_data = {
+            "oldPassword": oldPassword,
+            "newPassword": newPassword,
+            "confirmPassword": newPassword,
+            "sessionTimeout": sessionTimeout
+        }
+
+        return isvgAppliance.invoke_put("Setting admin password", "/admin_cfg", json_data, warnings=warnings)
+
+
+def set(isvgAppliance, oldPassword=None, newPassword=None, sessionTimeout=30, check_mode=False, force=False):
+    """
+    Updating the administrator settings
+    """
+    warnings = []
+    if force is False:
+        update_required, warnings, json_data = _check(isvgAppliance, oldPassword, newPassword, sessionTimeout, warnings)
+
+    if force is True or update_required is True:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True, warnings=warnings)
+        else:
+            return isvgAppliance.invoke_put(
+                "Updating the administrator settings",
+                "/admin_cfg", json_data, warnings=warnings)
+
+    return isvgAppliance.create_return_object(changed=False, warnings=warnings)
+
+
+def _check(isvgAppliance, oldPassword, newPassword, sessionTimeout, warnings):
+    """
+    Check whether target key has already been set with the value
+    :param isvgAppliance:
+    :param key:
+    :param value:
+    :return: True/False
+    """
+    ret_obj = get(isvgAppliance)
+
+    json_data = {
+        "sessionTimeout": sessionTimeout
+    }
+    if oldPassword is not None:
+        json_data["oldPassword"] = oldPassword
+        if newPassword is None:
+            warnings.append("Please provide new password, when old password is specified.")
+    if newPassword is not None:
+        warnings.append("Password change requested - cannot query existing password for idempotency check.")
+        json_data["newPassword"] = newPassword
+        json_data["confirmPassword"] = newPassword
+        if oldPassword is None:
+            warnings.append("Please provide old password, when new password is specified.")
+
+    if ibmsecurity.utilities.tools.json_sort(json_data) != ibmsecurity.utilities.tools.json_sort(ret_obj['data']):
+        logger.debug("Admin Settings are found to be different. See following JSON for difference.")
+        logger.debug("New JSON: {0}".format(ibmsecurity.utilities.tools.json_sort(json_data)))
+        logger.debug("Old JSON: {0}".format(ibmsecurity.utilities.tools.json_sort(ret_obj['data'])))
+        return True, warnings, json_data
+    else:  # No changes required
+        return False, warnings, json_data
+
+
+def compare(isvgAppliance1, isvgAppliance2):
+    """
+    Compare advanced tuning parameters between two appliances
+    """
+    ret_obj1 = get(isvgAppliance1)
+    ret_obj2 = get(isvgAppliance2)
+
+    return ibmsecurity.utilities.tools.json_compare(ret_obj1, ret_obj2)

--- a/ibmsecurity/isvg/advanced_tuning_parameters.py
+++ b/ibmsecurity/isvg/advanced_tuning_parameters.py
@@ -1,0 +1,146 @@
+import logging
+import ibmsecurity.utilities.tools
+
+logger = logging.getLogger(__name__)
+
+
+def get(isvgAppliance, check_mode=False, force=False):
+    """
+    Get advanced tuning parameters
+    """
+    return isvgAppliance.invoke_get("Get advanced tuning parameters",
+                                    "/adv_params")
+
+
+def set(isvgAppliance, key, value, comment="", check_mode=False, force=False):
+    """
+    Set advanced tuning parameter
+
+    Note: Pass an array of values if needed to set a set of values for given key
+
+    Advanced Tuning Parameters functionality available starting with 8.0.1.9 only
+    """
+
+    if ibmsecurity.utilities.tools.version_compare(isvgAppliance.facts["version"], "8.0.1.9") < 0:
+        warnings = []
+        warnings.append(
+            "Appliance at version: {0}, 'Advanced Tuning Parameters' is not supported. Needs 8.0.1.9 or higher. Ignoring 'Advanced Tuning Parameters' for this call.".format(
+                isvgAppliance.facts["version"]))
+        return isvgAppliance.create_return_object(warnings=warnings)
+
+    ret_obj = isvgAppliance.create_return_object()
+    ret_obj['data'] = []
+    rc, uuid = False, []
+    # Force the value to be an array if not already so
+    if not isinstance(value, list):
+        value = [value]
+    (rc, uuid) = _check(isvgAppliance, key, value)
+
+    # See if change detected or are being forced to do so
+    if rc is False or force is True:
+        if check_mode is True:
+            ret_obj['changed'] = True
+        else:
+            # Remove any existing values...
+            if len(uuid) > 0:
+                _del(isvgAppliance, uuid)
+            # Add all new/modified values
+            for v in value:
+                r = isvgAppliance.invoke_post(
+                    "Adding advanced tuning parameter",
+                    "/adv_params",
+                    {
+                        '_isNew': True,
+                        'comment': comment,
+                        'key': key,
+                        'value': v
+                    })
+                ret_obj['changed'] = ret_obj['changed'] or r['changed']
+                ret_obj['data'].append(r['data'])
+                ret_obj['warnings'].extend(r['warnings'])
+                ret_obj['rc'] += r['rc']
+
+    return ret_obj
+
+
+def _check(isvgAppliance, key, value=None):
+    ret_obj = get(isvgAppliance)
+
+    rc = False
+    uuid = []
+    exist_value_list = []
+    for param in ret_obj['data']['tuningParameters']:
+        if param['key'] == key:
+            exist_value_list.append(str(param['value']))
+            uuid.append(param['uuid'])
+            logger.info("Advanced tuning parameter key: {0} and value: {1} exists".format(key, value))
+
+    # value being none - means called from delete function
+    if value is not None:
+        given_value_list = []
+        for v in value:
+            given_value_list.append(str(v))
+        rc = ibmsecurity.utilities.tools.json_sort(exist_value_list) == ibmsecurity.utilities.tools.json_sort(
+            given_value_list)
+        logger.info(
+            "Advanced tuning parameter: {0} has existing values: {1}, and given values: {2} - match status: {3}".format(
+                key, exist_value_list, given_value_list, rc))
+
+    return rc, uuid
+
+
+def delete(isvgAppliance, key, check_mode=False, force=False):
+    """
+    Delete advanced tuning parameter
+    """
+    ret_obj = isvgAppliance.create_return_object()
+    (rc, uuid) = _check(isvgAppliance, key)
+
+    if len(uuid) > 0:
+        if check_mode is True:
+            ret_obj['changed'] = True
+        else:
+            ret_obj = _del(isvgAppliance, uuid)
+
+    return ret_obj
+
+
+def _del(isvgAppliance, uuid):
+    """
+    Remove all UUIDs - should be everything pertaining to an advanced tuning parameter "key"
+
+    :param isvgAppliance:
+    :param uuid:
+    :return:
+    """
+    ret_obj = isvgAppliance.create_return_object()
+    ret_obj['data'] = []
+
+    for u in uuid:
+        r = isvgAppliance.invoke_delete(
+            "Deleting existing advanced tuning parameter",
+            "/adv_params/{0}".format(u))
+        ret_obj['changed'] = ret_obj['changed'] or r['changed']
+        ret_obj['data'].append(r['data'])
+        ret_obj['warnings'].extend(r['warnings'])
+        ret_obj['rc'] += r['rc']
+
+    return ret_obj
+
+
+def compare(isvgAppliance1, isvgAppliance2):
+    """
+    Compare advanced tuning parameters between two appliances
+    """
+    ret_obj1 = get(isvgAppliance1)
+    ret_obj2 = get(isvgAppliance2)
+
+    # Ignore differences between comments/uuid as they are immaterial
+    for param in ret_obj1['data']['tuningParameters']:
+        del param['comment']
+        del param['uuid']
+    for param in ret_obj2['data']['tuningParameters']:
+        del param['comment']
+        del param['uuid']
+
+    return ibmsecurity.utilities.tools.json_compare(ret_obj1, ret_obj2, deleted_keys=['comment', 'uuid'])

--- a/ibmsecurity/isvg/appliance.py
+++ b/ibmsecurity/isvg/appliance.py
@@ -1,0 +1,129 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def reboot(isvgAppliance, check_mode=False, force=False):
+    """
+    Reboot the appliance
+    """
+    if check_mode is True:
+        return isvgAppliance.create_return_object(changed=True)
+    else:
+        # obtain appliance lastboot time
+        import ibmsecurity.isvg.firmware
+        import time
+        ret_obj_appliance = ibmsecurity.isvg.firmware.get(isvgAppliance)
+        for firm in ret_obj_appliance['data']:
+            if firm['active'] is True:
+                before_reboot_last_boot = firm['last_boot']
+                logger.info(
+                    "Active partition last boot time {0} before reboot process initiated.".format(before_reboot_last_boot))
+    
+        ret_obj = isvgAppliance.invoke_post("Rebooting appliance",
+                                         "/diagnostics/restart_shutdown/reboot",
+                                         {})
+
+        # Depending on resource allocated, isvg appliance can take up to 30s or more before it reboots
+        # after it is being told to do so.
+        # Loop until appliance returns an error, or reboot is detected, before returning control.
+        try:
+            while True:
+                ret_obj_appliance = ibmsecurity.isvg.firmware.get(isvgAppliance)
+                for firm in ret_obj_appliance['data']:
+                    if firm['active'] is True:
+                        last_boot = firm['last_boot']
+                        logger.info(
+                            "Active partition last boot time {0} after reboot process initiated.".format(last_boot))
+                        if last_boot > before_reboot_last_boot:
+                            raise Exception ("Break out of loop")
+                time.sleep(15)
+        except Exception as e:
+            logger.debug("Exception occured: {0}. Assuming appliance has now initiated reboot process".format(e))
+            pass
+        
+        return ret_obj
+
+
+def shutdown(isvgAppliance, check_mode=False, force=False):
+    """
+    Shutdown the appliance
+    """
+    if check_mode is True:
+        return isvgAppliance.create_return_object(changed=True)
+    else:
+        return isvgAppliance.invoke_post("Shutting down appliance",
+                                         "/diagnostics/restart_shutdown/shutdown",
+                                         {})
+
+
+def _changes_available(isvgAppliance):
+    """
+    Check for pending changes on the appliance
+    :param isvgAppliance:
+    :return:
+    """
+    #    changes = isvgAppliance.invoke_get("Get pending changes",
+    #                                       "/pending_changes")
+    #    logger.debug("Pending changes on appliance are:")
+    #    logger.debug(changes['data'])
+    #
+    #    change_count = isvgAppliance.invoke_get("Get pending changes count",
+    #                                            "/pending_changes/count")
+    #    logger.debug("Pending change count on appliance is:")
+    #    logger.debug(change_count['data'])
+    #
+    #    if change_count['data']['count'] > 0 or len(changes['data']['changes']) > 0:
+    #        logger.info("pending changes found")
+    #        return True
+    #    else:
+    #        return False
+
+    return True
+
+
+def commit(isvgAppliance, check_mode=False, force=False):
+    """
+    Commit the current pending changes.
+    """
+    if force is True or _changes_available(isvgAppliance) is True:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True)
+        else:
+            return isvgAppliance.invoke_get("Committing the changes",
+                                            "/pending_changes/deploy",
+                                            {})
+
+    return isvgAppliance.create_return_object()
+
+
+def commit_and_restart(isvgAppliance, check_mode=False, force=False):
+    """
+    Commit and Restart LMI
+    :param isvgAppliance:
+    :param check_mode:
+    :param force:
+    :return:
+    """
+    if force is True or _changes_available(isvgAppliance) is True:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True)
+        else:
+            return isvgAppliance.invoke_post("Commit and Restart",
+                                             "/restarts/commit_and_restart",
+                                             {})
+    return isvgAppliance.create_return_object()
+
+
+def rollback(isvgAppliance, check_mode=False, force=False):
+    """
+    Rollback the current pending changes.
+    """
+    if force is True or _changes_available(isvgAppliance) is True:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True)
+        else:
+            return isvgAppliance.invoke_get("Rollback the changes",
+                                            "/pending_changes/forget")
+
+    return isvgAppliance.create_return_object()

--- a/ibmsecurity/isvg/available_updates.py
+++ b/ibmsecurity/isvg/available_updates.py
@@ -1,0 +1,178 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def get(isvgAppliance, check_mode=False, force=False):
+    """
+    Retrieve available updates
+    """
+    return isvgAppliance.invoke_get("Retrieving available updates",
+                                    "/updates/available.json")
+
+
+def discover(isvgAppliance, check_mode=False, force=False):
+    """
+    Discover available updates
+    """
+    return isvgAppliance.invoke_get("Discover available updates",
+                                    "/updates/available/discover")
+
+
+def upload(isvgAppliance, file, check_mode=False, force=False):
+    """
+    Upload Available Update
+    """
+    if force is True or _check_file(isvgAppliance, file) is False:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True)
+        else:
+            return isvgAppliance.invoke_post_files(
+                "Upload Available Update",
+                "/updates/available",
+                [{
+                    'file_formfield': 'uploadedfile',
+                    'filename': file,
+                    'mimetype': 'application/octet-stream'
+                }],
+                {}, json_response=False)
+
+    return isvgAppliance.create_return_object()
+
+
+def _check_file(isvgAppliance, file):
+    """
+    Parse the file name to see if it is already uploaded - use version and release date from pkg file name
+    Also check to see if the firmware level is already uploaded
+    Note: Lot depends on the name of the file.
+
+    :param isvgAppliance:
+    :param file:
+    :return:
+    """
+    import os.path
+
+    # If there is an exception then simply return False
+    # Sample filename - 8.0.1.9-ISS-ISVG_20181207-0045.pkg
+    logger.debug("Checking provided file is ready to upload: {0}".format(file))
+    try:
+        # Extract file name from path
+        f = os.path.basename(file)
+        fn = os.path.splitext(f)
+        logger.debug("File name without path: {0}".format(fn[0]))
+
+        # Split of file by '-' hyphen and '_' under score
+        import re
+        fp = re.split('-|_', fn[0])
+        firm_file_version = fp[0]
+        firm_file_product = fp[2]
+        firm_file_date = fp[3]
+        logger.debug("PKG file details: {0}: version: {1} date: {2}".format(firm_file_product, firm_file_version, firm_file_date))
+
+        # Check if firmware level already contains the update to be uploaded or greater, check Active partition
+        # firmware "name" of format - 8.0.1.9-ISS-ISVG_20181207-0045
+        import ibmsecurity.isvg.firmware
+        ret_obj = ibmsecurity.isvg.firmware.get(isvgAppliance)
+        for firm in ret_obj['data']:
+            # Split of file by '-' hyphen and '_' under score
+            fp = re.split('-|_', firm['name'])
+            firm_appl_version = fp[0]
+            firm_appl_product = fp[2]
+            firm_appl_date = fp[3]
+            logger.debug("Partition details ({0}): {1}: version: {2} date: {3}".format(firm['partition'], firm_appl_product, firm_appl_version, firm_appl_date))
+            if firm['active'] is True:
+                from ibmsecurity.utilities import tools
+                if tools.version_compare(firm_appl_version, firm_file_version) >= 0:
+                    logger.info(
+                        "Active partition has version {0} which is greater or equals than install package at version {1}.".format(
+                            firm_appl_version, firm_file_version))
+                    return True
+                else:
+                    logger.info(
+                        "Active partition has version {0} which is smaller than install package at version {1}.".format(
+                            firm_appl_version, firm_file_version))
+
+        # Check if update uploaded - will not show up if installed though
+        ret_obj = get(isvgAppliance)
+        for upd in ret_obj['data']:
+            rd = upd['release_date']
+            rd = rd.replace('-', '')  # turn release date into 20161102 format from 2016-11-02
+            if upd['version'] == fp[0] and rd == fp[3]:  # Version of format 8.0.1.9
+                return True
+    except Exception as e:
+        logger.debug("Exception occured: {0}".format(e))
+        pass
+
+    return False
+
+
+def install(isvgAppliance, type, version, release_date, name, check_mode=False, force=False):
+    """
+    Install Available Update
+    """
+    if force is True or _check(isvgAppliance, type, version, release_date, name) is True:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True)
+        else:
+            # obtain appliance lastboot time
+            import ibmsecurity.isvg.firmware
+            import time
+            ret_obj_appliance = ibmsecurity.isvg.firmware.get(isvgAppliance)
+            for firm in ret_obj_appliance['data']:
+                if firm['active'] is True:
+                    before_install_last_boot = firm['last_boot']
+                    logger.info(
+                        "Active partition last boot time {0} before firmware installation.".format(before_install_last_boot))
+            
+            # proceed with firmware installation
+            ret_obj = isvgAppliance.invoke_post("Install Available Update",
+                                                "/updates/available/install",
+                                                {"updates": [
+                                                    {
+                                                        "type": type,
+                                                        "version": version,
+                                                        "release_date": release_date,
+                                                        "name": name
+                                                    }
+                                                ]
+                                                })
+            isvgAppliance.facts['version'] = version
+            
+            # isvg appliance has so much work to do after installing the firmware, it can take up
+            # to several minutes before it reboots by itself.
+            # Loop until appliance returns an error, or reboot is detected, before returning control.
+            try:
+                while True:
+                    ret_obj_appliance = ibmsecurity.isvg.firmware.get(isvgAppliance)
+                    for firm in ret_obj_appliance['data']:
+                        if firm['active'] is True:
+                            last_boot = firm['last_boot']
+                            logger.info(
+                                "Active partition last boot time {0} after firmware installation.".format(last_boot))
+                            if last_boot > before_install_last_boot:
+                                raise Exception ("Break out of loop")
+                    time.sleep(30)
+            except Exception as e:
+                logger.debug("Exception occured: {0}. Assuming appliance has now initiated reboot process".format(e))
+                pass
+            
+            return ret_obj
+
+    return isvgAppliance.create_return_object()
+
+
+def _check(isvgAppliance, type, version, release_date, name):
+    ret_obj = get(isvgAppliance)
+    for upd in ret_obj['data']:
+        # If there is an installation in progress then abort
+        if upd['state'] == 'Installing':
+            logger.debug("Detecting a state of installing...")
+            return False
+        if upd['type'] == type and upd['version'] == version and upd['release_date'] == release_date and upd[
+            'name'] == name:
+            logger.debug("Requested firmware ready for install...")
+            return True
+
+    logger.debug("Requested firmware not available for install...")
+
+    return False

--- a/ibmsecurity/isvg/certstore_personal.py
+++ b/ibmsecurity/isvg/certstore_personal.py
@@ -1,0 +1,80 @@
+import logging
+from ibmsecurity.utilities import tools
+
+logger = logging.getLogger(__name__)
+
+uri = "/certstore_object"
+
+
+def get_all(isvgAppliance, check_mode=False, force=False):
+    """
+    Get personal cert store entries
+    """
+    return isvgAppliance.invoke_get("Retrieving cert store entries",
+                                    uri + "/key/certificates?type=personal")
+
+
+def search(isvgAppliance, label, check_mode=False, force=False):
+    """
+    Search for existing certificate by label
+    """
+    ret_obj = get_all(isvgAppliance)
+    return_obj = isvgAppliance.create_return_object()
+
+    for obj in ret_obj['data']:
+        if 'id' in obj and obj['label'] == label:
+            logger.info("Found cert entry: {0}".format(obj['label']))
+            return_obj['data'] = obj
+            return_obj['rc'] = 0
+            break
+
+    return return_obj
+    
+
+def upload(isvgAppliance, db, type, password, label="lmi", check_mode=False, force=False):
+    """
+    Import personal certificate from db
+    """
+    warnings = []
+
+    file_short = tools.path_leaf(db);
+    if force is True or not _check(isvgAppliance, label):
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True, warnings=warnings)
+        else:
+            return isvgAppliance.invoke_post_files(
+                "Import personal certificate",
+                uri + "/key/certificates/upload",
+                [
+                    {
+                        'file_formfield': 'uploadedfile',
+                        'filename': db,
+                        'mimetype': 'application/octet-stream'
+                    }
+                ],
+                {
+                    'fileName': file_short,
+                    'cert_name': label,
+                    'file_password': password,
+                    'file_type': type,
+                    'is_getting_val': 'false',
+                    'cert_type': 'personal',
+                    'uploadType':'iframe'
+                },
+                json_response=False)
+
+    return isvgAppliance.create_return_object()
+
+
+def _check(isvgAppliance, label):
+    """
+    Check if personal cert needs to be uploaded
+    """
+    ret_obj = search(isvgAppliance, label)
+
+    # Bogus check for now - real test will involve downloading the public personal certificate
+    # and compare it with the reference one.
+    if len(ret_obj['data']) > 0:
+        return True
+    else:
+        return False

--- a/ibmsecurity/isvg/certstore_signer.py
+++ b/ibmsecurity/isvg/certstore_signer.py
@@ -1,0 +1,76 @@
+import logging
+from ibmsecurity.utilities import tools
+
+logger = logging.getLogger(__name__)
+
+uri = "/certstore_object"
+
+
+def get_all(isvgAppliance, check_mode=False, force=False):
+    """
+    Get signer cert store entries
+    """
+    return isvgAppliance.invoke_get("Retrieving cert store entries",
+                                    uri + "/key/certificates?type=signer")
+
+
+def search(isvgAppliance, subject, check_mode=False, force=False):
+    """
+    Search for existing certificate by subject
+    """
+    ret_obj = get_all(isvgAppliance)
+    return_obj = isvgAppliance.create_return_object()
+
+    for obj in ret_obj['data']:
+        if 'id' in obj and obj['subject'] == subject:
+            logger.info("Found cert entry: {0}".format(obj['subject']))
+            return_obj['data'] = obj
+            return_obj['rc'] = 0
+            break
+
+    return return_obj
+    
+
+def upload(isvgAppliance, certificate, subject, label, check_mode=False, force=False):
+    """
+    Import signer certificate
+    """
+    warnings = []
+
+    file_short = tools.path_leaf(certificate);
+    if force is True or not _check(isvgAppliance, subject):
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True, warnings=warnings)
+        else:
+            return isvgAppliance.invoke_post_files(
+                "Import signer certificate",
+                uri + "/key/certificates/upload",
+                [
+                    {
+                        'file_formfield': 'uploadedfile',
+                        'filename': certificate,
+                        'mimetype': 'application/x-x509-ca-cert'
+                    }
+                ],
+                {
+                    'fileName': file_short,
+                    'cert_name': label,
+                    'is_getting_val': 'false',
+                    'cert_type': 'signer',
+                    'uploadType':'iframe'
+                },
+                json_response=True)
+
+    return isvgAppliance.create_return_object()
+
+
+def _check(isvgAppliance, subject):
+    """
+    Check if signer cert needs to be uploaded
+    """
+    ret_obj = search(isvgAppliance, subject)
+
+    if len(ret_obj['data']) > 0:
+        return True
+    else:
+        return False

--- a/ibmsecurity/isvg/cm/process.py
+++ b/ibmsecurity/isvg/cm/process.py
@@ -1,0 +1,54 @@
+import logging
+from ibmsecurity.utilities import tools
+from ibmsecurity.isvg import notifications
+
+logger = logging.getLogger(__name__)
+
+uri = "/widgets/server"
+
+def get(isvgAppliance, check_mode=False, force=False):
+    """
+    Get Cluster Manager server status
+    """
+    return isvgAppliance.invoke_get("Retrieving Cluster Manager server status", uri)
+
+
+def execute(isvgAppliance, operation="restart", check_mode=False, force=False):
+    """
+    Execute an operation (start, stop or restart) on Cluster Manager server
+    """
+    check_value, warnings = _check(isvgAppliance, operation)
+
+    if force is True or check_value is True:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True, warnings=warnings)
+        else:
+            return isvgAppliance.invoke_post(
+                "Executing an operation on Cluster Manager server", uri + "/" + operation + "/clustermanager",
+                {
+                    'operation': operation
+                }, warnings=warnings)
+
+    return isvgAppliance.create_return_object(warnings=warnings)
+
+
+def _check(isvgAppliance, operation):
+    """
+    Check if operation needs to be applied to process
+    """
+    ret_obj = notifications.get(isvgAppliance)
+    warnings = ret_obj['warnings']
+    
+    if ret_obj['rc'] == 0 and len(ret_obj['data']) > 0 and 'items' in ret_obj['data']:
+        for item in ret_obj['data']['items']:
+            # code not tested yet with the right message id
+            if 'message' in item and item['message'] == 'identity_was_server_restart_reqd' and operation == "restart":
+                logger.info("Cluster Manager server requires a restart")
+                return True,warnings
+    else:
+        logger.info(
+            "Executing {0} on Cluster Manager server not required or will not work. Use force if needed.".format(
+                operation))
+        return False,warnings
+
+    return False,warnings    

--- a/ibmsecurity/isvg/date_time.py
+++ b/ibmsecurity/isvg/date_time.py
@@ -1,0 +1,97 @@
+import logging
+import ibmsecurity.utilities.tools
+
+logger = logging.getLogger(__name__)
+
+
+def get(isvgAppliance, check_mode=False, force=False):
+    """
+    Get current date/time settings
+    """
+    return isvgAppliance.invoke_get("Retrieving current date and time settings",
+                                    "/time_cfg")
+
+
+def set(isvgAppliance, ntpServers, timeZone="America/New_York", check_mode=False, force=False):
+    """
+    Update date/time settings (set NTP server and timezone)
+    """
+    if force is True or _check(isvgAppliance, timeZone, ntpServers) is False:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True)
+        else:
+            return isvgAppliance.invoke_put(
+                "Setting date/time settings (NTP)",
+                "/time_cfg",
+                {
+                    "dateTime": "0000-00-00 00:00:00",
+                    "timeZone": timeZone,
+                    "enableNtp": True,
+                    "ntpServers": ntpServers
+                })
+
+    return isvgAppliance.create_return_object()
+
+
+def disable(isvgAppliance, check_mode=False, force=False):
+    """
+    Disable NTP settings, leaves all other settings intact
+    """
+    if force is False:
+        ret_obj = get(isvgAppliance)
+
+    if force is True or ret_obj['data']['ntpConfig']['enableNtp'] == True:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True)
+        else:
+            return isvgAppliance.invoke_put(
+                "Setting date/time settings (NTP)",
+                "/time_cfg",
+                {
+                    'dateTime': ret_obj['data']['dateTime'],
+                    'timeZone': ret_obj['data']['timeZone'],
+                    'enableNtp': False,
+                    'ntpServers': ','.join(ns['ntpServer'] for ns in ret_obj['data']['ntpConfig']['ntpServers'])
+                })
+
+    return isvgAppliance.create_return_object()
+
+
+def _check(isvgAppliance, timeZone=None, ntpServers=None):
+    """
+    Check if NTP is already set for syncing date/time
+    If timezone or ntpservers provided then also check if those values match what is currently set
+    """
+    ret_obj = get(isvgAppliance)
+
+    if ret_obj['data']['ntpConfig']['enableNtp']:
+        logger.info("NTP is already enabled")
+        if timeZone is not None and ret_obj['data']['timeZone'] != timeZone:
+            logger.info("Existing timeZone is different")
+            return False
+        if ntpServers != None:
+            existing_ntpServers = list()
+            for ntps in ret_obj['data']['ntpConfig']['ntpServers']:
+                existing_ntpServers.append(ntps['ntpServer'])
+            logger.debug(str(sorted(existing_ntpServers)))
+            logger.debug(str(sorted(ntpServers.split(','))))
+            if sorted(ntpServers.split(',')) != sorted(existing_ntpServers):
+                logger.debug("Existing ntpServers are different")
+                return False
+        return True
+    else:
+        return False
+
+
+def compare(isvgAppliance1, isvgAppliance2):
+    """
+    Compare date/time settings between two appliances
+    """
+    ret_obj1 = get(isvgAppliance1)
+    ret_obj2 = get(isvgAppliance2)
+
+    # Ignore actual date / time on servers - they should be same if synced correctly
+    del ret_obj1['data']['dateTime']
+    del ret_obj2['data']['dateTime']
+
+    return ibmsecurity.utilities.tools.json_compare(ret_obj1, ret_obj2, deleted_keys=['datetime'])

--- a/ibmsecurity/isvg/db/process.py
+++ b/ibmsecurity/isvg/db/process.py
@@ -1,0 +1,12 @@
+import logging
+from ibmsecurity.utilities import tools
+
+logger = logging.getLogger(__name__)
+
+uri = "/widgets/apphealth"
+
+def get(isvgAppliance, check_mode=False, force=False):
+    """
+    Get Identity Manager data stores status
+    """
+    return isvgAppliance.invoke_get("Retrieving Identity Manager data stores status", uri)

--- a/ibmsecurity/isvg/firmware.py
+++ b/ibmsecurity/isvg/firmware.py
@@ -1,0 +1,89 @@
+import logging
+import ibmsecurity.utilities.tools
+
+logger = logging.getLogger(__name__)
+
+
+def get(isvgAppliance, check_mode=False, force=False):
+    """
+    Retrieve existing firmware.
+    """
+    return isvgAppliance.invoke_get("Retrieving firmware",
+                                    "/firmware_settings")
+
+
+def backup(isvgAppliance, check_mode=False, force=False):
+    """
+    Kickoff Backup of active partition
+    """
+    if check_mode is True:
+        return isvgAppliance.create_return_object(changed=True)
+    else:
+        return isvgAppliance.invoke_put("Kickoff Backup of Active Partition",
+                                        "/firmware_settings/kickoff_backup", {})
+
+
+def swap(isvgAppliance, check_mode=False, force=False):
+    """
+    Kickoff swap of active partition
+    """
+    if check_mode is True:
+        return isvgAppliance.create_return_object(changed=True)
+    else:
+        ret_obj_old = get(isvgAppliance)
+
+        ret_obj = isvgAppliance.invoke_put("Kickoff swap of Active Partition",
+                                           "/firmware_settings/kickoff_swap", {})
+        # Process previous query after a successful call to swap the partition
+        for partition in ret_obj_old['data']:
+            if partition['active'] is False:  # Get version of inactive partition (active now!)
+                ver = partition['firmware_version'].split(' ')
+                isvgAppliance.facts['version'] = ver[-1]
+
+        return ret_obj
+
+
+def set(isvgAppliance, id, comment, check_mode=False, force=False):
+    """
+    Update comment on partition
+    """
+    if force is True or _check_comment(isvgAppliance, comment) is False:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True)
+        else:
+            return isvgAppliance.invoke_put("Update comment on Partition",
+                                            "/firmware_settings/{0}".format(id),
+                                            {'comment': comment})
+
+    return isvgAppliance.create_return_object()
+
+
+def _check_comment(isvgAppliance, comment):
+    ret_obj = get(isvgAppliance)
+
+    # Loop through firmware partitions looking for active one
+    for partition in ret_obj['data']:
+        if partition['active'] is True:
+            return (partition['comment'] == comment)
+
+    return False
+
+
+def compare(isvgAppliance1, isvgAppliance2):
+    """
+    Compare firmware between two appliances
+    """
+    ret_obj1 = get(isvgAppliance1)
+    ret_obj2 = get(isvgAppliance2)
+
+    for obj in ret_obj1['data']:
+        del obj['install_date']
+        del obj['backup_date']
+        del obj['last_boot']
+    for obj in ret_obj2['data']:
+        del obj['install_date']
+        del obj['backup_date']
+        del obj['last_boot']
+
+    return ibmsecurity.utilities.tools.json_compare(ret_obj1, ret_obj2,
+                                                    deleted_keys=['install_date', 'backup_date', 'last_boot'])

--- a/ibmsecurity/isvg/fixpack.py
+++ b/ibmsecurity/isvg/fixpack.py
@@ -1,0 +1,115 @@
+import logging
+import os.path
+import ibmsecurity.utilities.tools
+
+logger = logging.getLogger(__name__)
+
+
+def get(isvgAppliance, check_mode=False, force=False):
+    """
+    Retrieve existing fixpacks.
+    """
+    return isvgAppliance.invoke_get("Retrieving fixpacks",
+                                    "/fixpacks")
+
+
+def install(isvgAppliance, file, check_mode=False, force=False):
+    """
+    Install fixpack
+    """
+    if force is True or _check(isvgAppliance, file) is False:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True)
+        else:
+            return isvgAppliance.invoke_post_files(
+                "Install fixpack",
+                "/fixpacks",
+                [{
+                    'file_formfield': 'file',
+                    'filename': file,
+                    'mimetype': 'application/octet-stream'
+                }],
+                {})
+
+    return isvgAppliance.create_return_object()
+
+
+def _check(isvgAppliance, fixpack):
+    """
+    Check if fixpack is already installed
+    """
+    ret_obj = get(isvgAppliance)
+
+    fixpack_name = _extract_fixpack_name(fixpack)
+
+    # Reverse sort the json by 'id'
+    json_data_sorted = sorted(ret_obj['data'], key=lambda k: int(k['id']), reverse=True)
+    # Eliminate all rollbacks
+    del_fixpack = ''  # Delete succeeding fixpack to a rollback, only last fixpack can be rolled back
+    for fixpack in json_data_sorted:
+        if fixpack['action'] == 'Uninstalled':
+            del_fixpack = fixpack['name']
+        elif del_fixpack == fixpack['name'] and fixpack['rollback'] == 'Yes':
+            del_fixpack = ''
+        elif fixpack['name'].lower() == fixpack_name.lower():
+            return True
+
+    return False
+
+
+def _extract_fixpack_name(fixpack):
+    """
+    Extract fixpack name from the given fixpack
+    """
+    import re
+
+    # Look for the follwing string inside the fixpack file
+    # FIXPACK_NAME="9021_IPv6_Routes_fix"
+    for s in ibmsecurity.utilities.tools.strings(fixpack):
+        match_obj = re.search(r"FIXPACK_NAME=\"(?P<fp_name>\w+)\"", s)
+        if match_obj:
+            logger.info("Fixpack name extracted from file using strings method: {0}".format(match_obj.group('fp_name')))
+            return match_obj.group('fp_name')
+
+    # Unable to extract fixpack name from binary
+    # Return fixpack name derived from the filename
+    logger.debug(fixpack)
+    file_name = os.path.basename(fixpack)
+    fixpack_name, ext_name = file_name.split('.fixpack')
+    logger.debug("Extracted fixpack_name: " + fixpack_name)
+    return fixpack_name
+
+
+def compare(isvgAppliance1, isvgAppliance2):
+    """
+    Compare fixpacks between two appliances
+    Sort in reverse order and remove fixpacks that were rolled back before compare
+    """
+    ret_obj1 = get(isvgAppliance1)
+    ret_obj2 = get(isvgAppliance2)
+
+    json_data1_sorted = sorted(ret_obj1['data'], key=lambda k: int(k['id']), reverse=True)
+    del_fixpack = ''  # Delete succeeding fixpack to a rollback, only last fixpack can be rolled back
+    for fixpack in json_data1_sorted:
+        if fixpack['action'] == 'Uninstalled':
+            del_fixpack = fixpack['name']
+            del fixpack
+        elif del_fixpack == fixpack['name'] and fixpack['rollback'] == 'Yes':
+            del_fixpack = ''
+            del fixpack
+        else:
+            del fixpack['date']
+
+    json_data2_sorted = sorted(ret_obj2['data'], key=lambda k: int(k['id']), reverse=True)
+    del_fixpack = ''  # Delete succeeding fixpack to a rollback, only last fixpack can be rolled back
+    for fixpack in json_data2_sorted:
+        if fixpack['action'] == 'Uninstalled':
+            del_fixpack = fixpack['name']
+            del fixpack
+        elif del_fixpack == fixpack['name'] and fixpack['rollback'] == 'Yes':
+            del_fixpack = ''
+            del fixpack
+        else:
+            del fixpack['date']
+
+    return ibmsecurity.utilities.tools.json_compare(ret_obj1, ret_obj2, deleted_keys=[])

--- a/ibmsecurity/isvg/host_records.py
+++ b/ibmsecurity/isvg/host_records.py
@@ -1,0 +1,75 @@
+import logging
+import ibmsecurity.utilities.tools
+
+logger = logging.getLogger(__name__)
+
+
+def get(isvgAppliance, check_mode=False, force=False):
+    """
+    Get host records
+    """
+    return isvgAppliance.invoke_get("Retrieving current host records",
+                                    "/host_records")
+
+
+def set(isvgAppliance, hostname, ip_addr, check_mode=False, force=False):
+    """
+    Add host records
+    """
+    if force is True or _check(isvgAppliance, hostname, ip_addr) is False:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True)
+        else:
+            return isvgAppliance.invoke_post(
+                "Setting host record",
+                "/host_records",
+                {
+                    'hostnames': [{"name": hostname}],
+                    'addr': ip_addr
+                })
+
+    return isvgAppliance.create_return_object()
+
+
+def delete(isvgAppliance, hostname, ip_addr, check_mode=False, force=False):
+    """
+    Delete a host record
+    :param isvgAppliance:
+    :param hostname:
+    :param ip_addr:
+    :param check_mode:
+    :param force:
+    :return:
+    """
+    if force is True or _check(isvgAppliance, hostname, ip_addr) is True:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True)
+        else:
+            return isvgAppliance.invoke_delete(
+                "Removing host record",
+                "/host_records/" + ip_addr,
+                {
+                })
+    return isvgAppliance.create_return_object()
+
+
+def _check(isvgAppliance, hostname, ip_addr, check_mode=False, force=False):
+    """
+    check whether hostname has been defined
+    :param isvgAppliance:
+    :param hostname:
+    :param ip_addr:
+    :param check_mode:
+    :param force:
+    :return:
+    """
+    ret_obj = get(isvgAppliance)
+
+    for hosts in ret_obj['data']:
+        if hosts['addr'] == ip_addr:
+            for names in hosts['hostnames']:
+                if names['name'] == hostname:
+                    logger.info("hostname record exists, skip")
+                    return True
+
+    return False

--- a/ibmsecurity/isvg/hostnames.py
+++ b/ibmsecurity/isvg/hostnames.py
@@ -1,0 +1,59 @@
+import logging
+import ibmsecurity.utilities.tools
+
+logger = logging.getLogger(__name__)
+
+
+def get(isvgAppliance, ip_addr, check_mode=False, force=False):
+    """
+    Get hostnames for a host record
+    """
+    return isvgAppliance.invoke_get("Retrieving hostnames for a host record",
+                                    "/host_records/" + ip_addr + "/hostnames")
+
+
+def add(isvgAppliance, hostname, ip_addr, check_mode=False, force=False):
+    """
+    Add hostname to host record
+    """
+    if force is True or _check(isvgAppliance, hostname, ip_addr) is False:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True)
+        else:
+            return isvgAppliance.invoke_post(
+                "Adding hostname to host record",
+                "/host_records/" + ip_addr + "/hostnames",
+                {
+                    'name': hostname
+                })
+
+    return isvgAppliance.create_return_object()
+
+
+def delete(isvgAppliance, hostname, ip_addr, check_mode=False, force=False):
+    """
+    Delete a hostname from a host record
+    """
+    if force is True or _check(isvgAppliance, hostname, ip_addr) is True:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True)
+        else:
+            return isvgAppliance.invoke_delete(
+                "Removing hostname",
+                "/host_records/" + ip_addr + "/hostnames/" + hostname)
+
+    return isvgAppliance.create_return_object()
+
+
+def _check(isvgAppliance, hostname, ip_addr, check_mode=False, force=False):
+    """
+    Check whether hostname has been defined
+    """
+    ret_obj = get(isvgAppliance, ip_addr)
+
+    for names in ret_obj['data']:
+        if names['name'] == hostname:
+            logger.info("Hostname record exists")
+            return True
+
+    return False

--- a/ibmsecurity/isvg/im/certstore_personal.py
+++ b/ibmsecurity/isvg/im/certstore_personal.py
@@ -1,0 +1,82 @@
+import logging
+from ibmsecurity.utilities import tools
+
+logger = logging.getLogger(__name__)
+
+uri = "/cert_object"
+
+
+def get(isvgAppliance, check_mode=False, force=False):
+    """
+    Get personal cert store entry
+    """
+    return isvgAppliance.invoke_get("Retrieving cert store entry", uri)
+
+
+def search(isvgAppliance, serial, check_mode=False, force=False):
+    """
+    Search for existing certificate by serial
+    """
+    ret_obj = get(isvgAppliance)
+    return_obj = isvgAppliance.create_return_object()
+
+    if 'serialnumber' in ret_obj['data'] and ret_obj['data']['serialnumber'] == int(serial):
+        logger.info("Found cert entry: {0}".format(ret_obj['data']['serialnumber']))
+        return_obj['data'] = ret_obj['data']
+        return_obj['rc'] = 0
+
+    return return_obj
+    
+
+def upload(isvgAppliance, db, type, password, serial, check_mode=False, force=False):
+    """
+    Import personal certificate from db
+    """
+    warnings = []
+
+    file_short = tools.path_leaf(db);
+    if force is True or not _check(isvgAppliance, serial):
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True, warnings=warnings)
+        else:
+            ret_obj = isvgAppliance.invoke_post_files(
+                "Import personal certificate", 
+                "/upload_object",
+                [
+                    {
+                        'file_formfield': 'uploadedfile',
+                        'filename': db,
+                        'mimetype': 'application/x-pkcs12'
+                    }
+                ],
+                {
+                    'keyFilePassword': password,
+                    'upload_file_type': 'app_ssl_cert'
+                },
+                json_response=False)
+
+            warnings = ret_obj['warnings']
+
+            if ret_obj["rc"] == 0:
+                cert_json = {
+                   "fileName": file_short,
+                   "keyFilePassword": password,
+                   "storeType": type
+                }
+
+                return isvgAppliance.invoke_post(
+                    "Save personal certificate", "/cert_object/", cert_json, warnings=warnings)
+
+    return isvgAppliance.create_return_object()
+
+
+def _check(isvgAppliance, serial):
+    """
+    Check if personal cert needs to be uploaded
+    """
+    ret_obj = search(isvgAppliance, serial)
+
+    if len(ret_obj['data']) > 0:
+        return True
+    else:
+        return False

--- a/ibmsecurity/isvg/im/certstore_signer.py
+++ b/ibmsecurity/isvg/im/certstore_signer.py
@@ -1,0 +1,126 @@
+import logging
+import hashlib
+from ibmsecurity.utilities import tools
+
+logger = logging.getLogger(__name__)
+
+uri = "/sslcert_object"
+
+
+def get_all(isvgAppliance, check_mode=False, force=False):
+    """
+    Get signer certificate entries
+    """
+    return isvgAppliance.invoke_get("Retrieving signer certificate entries", uri)
+
+
+def search(isvgAppliance, label, check_mode=False, force=False):
+    """
+    Search for signer certificate by label
+    """
+    ret_obj = get_all(isvgAppliance)
+    return_obj = isvgAppliance.create_return_object()
+
+    for obj in ret_obj['data']:
+        logger.debug("obj {0}".format(obj))
+        if 'certAlias' in obj and obj['certAlias'] == label:
+            logger.info("Found certificate entry: {0}".format(obj['certAlias']))
+            return_obj['data'] = obj
+            return_obj['rc'] = 0
+            break
+
+    return return_obj
+    
+
+def upload(isvgAppliance, certificate, label, check_mode=False, force=False):
+    """
+    Import signer certificate
+    """
+    warnings = []
+
+    if force is True or not _check(isvgAppliance, certificate, label):
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True, warnings=warnings)
+        else:
+            file_short = tools.path_leaf(certificate);
+            ret_obj = isvgAppliance.invoke_post_files(
+                "Import signer certificate",
+                "/upload_object/" + file_short,
+                [
+                    {
+                        'file_formfield': 'uploadedfile',
+                        'filename': certificate,
+                        'mimetype': 'application/x-x509-ca-cert'
+                    }
+                ],
+                {
+                    'certAlias': label,
+                    'certLocation': file_short,
+                    'upload_file_type': 'ssl_cert'
+                },
+                json_response=False)
+
+            warnings = ret_obj['warnings']
+
+            if ret_obj["rc"] == 0:
+                certificate_json = {
+                   "name": label,
+                   "certLocation": file_short,
+                   "certAlias": label,
+                   "_isNew": True,
+                   "action":"configure",
+                   "uploadedfile":[
+                      {
+                         "index":0,
+                         "name": file_short,
+                         "type": "application/x-x509-ca-cert"
+                      }
+                   ]
+                }
+
+                return isvgAppliance.invoke_post(
+                    "Save signer certificate metadata", uri + "/", certificate_json, warnings=warnings)
+
+    return isvgAppliance.create_return_object()
+
+
+def delete(isvgAppliance, certificate, check_mode=False, force=False):
+    """
+    Delete signer certificate
+    """
+    warnings = []
+    
+    ret_obj = search(isvgAppliance, label, check_mode=check_mode, force=force)
+
+    if force is True or ret_obj['data'] != {}:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True, warnings=warnings)
+        else:
+            if 'uuid' in ret_obj['data']:
+                uuid = ret_obj['data']['uuid']
+                warnings = ret_obj['warnings']
+                return isvgAppliance.invoke_delete(
+                    "Delete an external certificate", "{0}/{1}".format(uri, uuid), warnings=warnings)
+
+    return isvgAppliance.create_return_object(warnings=warnings)
+
+
+def _check(isvgAppliance, certificate, label):
+    """
+    Check if signer certificate needs to be uploaded
+    """
+    ret_obj = search(isvgAppliance, label)
+
+    if len(ret_obj['data']) > 0 and 'checkSum' in ret_obj['data']:
+        applianceCheckSum = ret_obj['data']['checkSum']
+        with open(certificate, "rb") as f:
+            bytes = f.read()
+        localCheckSum = hashlib.sha256(bytes).hexdigest()
+        logger.debug("applianceCheckSum={0}".format(applianceCheckSum))
+        logger.debug("localCheckSum={0}".format(localCheckSum))
+        if applianceCheckSum == localCheckSum:
+            return True
+        else:
+            return False
+    else:
+        return False

--- a/ibmsecurity/isvg/im/db.py
+++ b/ibmsecurity/isvg/im/db.py
@@ -1,0 +1,313 @@
+import logging
+from ibmsecurity.utilities import tools
+
+logger = logging.getLogger(__name__)
+
+# URI for this module
+uri = "/db_object"
+
+
+def get(isvgAppliance, check_mode=False, force=False):
+    """
+    Retrieve identity data store configuration
+    """
+    return isvgAppliance.invoke_get("Retrieve identity data store configuration entries", "{0}".format(uri))
+
+
+def search(isvgAppliance, name, check_mode=False, force=False):
+    """
+    Search for existing identity data store configuration.
+    """
+    ret_obj = get(isvgAppliance)
+    return_obj = isvgAppliance.create_return_object()
+
+    for obj in ret_obj['data']:
+        if 'name' in obj and obj['name'] == name:
+            logger.info("Found db entry: {0}".format(obj['name']))
+            return_obj['data'] = obj
+            return_obj['rc'] = 0
+
+    return return_obj
+
+
+def add(isvgAppliance, name, hostName, port, dbName, adminName, adminPwd, userName, userPwd, configuredAs, retryInterval, maximumRetries, existingDB, oracleSvce, oracleLocationName, dropTables, useSSL, altServerNames, altPortNumbers, connTimeOut, maxConn, minConn, reapTime, agedTimeout, unusedTimeout, check_mode=False, force=False):
+    """
+    Updating identity data store configuration
+    """
+    if force is True:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True)
+        else:
+            if existingDB == ['true']:
+                # Reconfiguration does not update the database schema. It configures only the Identity Manager database details.
+                action = "reconfigure"
+            else:
+                # Configuration updates the database schema, in addition it configures the Identity Manager database details.
+                action = "configure"
+
+            return isvgAppliance.invoke_post(
+                "Configure identity data store", "{0}".format(uri),
+                    {
+                      "name": name,
+                      "hostName": hostName,
+                      "port": port,
+                      "dbName": dbName,
+                      "oracleLocationName": oracleLocationName, 
+                      "adminName": adminName,
+                      "adminPwd": adminPwd,
+                      "userName": userName,
+                      "userPwd": userPwd,
+                      "configuredAs": configuredAs,
+                      "dropTables": dropTables,
+                      "action": action,
+                      "useSSL": useSSL,
+                      "altServerNames": altServerNames,
+                      "altPortNumbers": altPortNumbers,
+                      "retryInterval": retryInterval,
+                      "maximumRetries": maximumRetries,
+                      "connTimeOut": connTimeOut,
+                      "maxConn": maxConn,
+                      "minConn": minConn,
+                      "reapTime": reapTime,
+                      "unusedTimeout": unusedTimeout,
+                      "agedTimeout": agedTimeout,
+                      "_isNew": True,
+                      "existingDB": existingDB,
+                      "oracleSvce": oracleSvce
+                    })
+
+    return isvgAppliance.create_return_object(changed=False)
+
+
+def delete(isvgAppliance, name, check_mode=False, force=False):
+    """
+    Un-configure identity data store
+    """
+    ret_obj = search(isvgAppliance, name)
+    warnings = ret_obj['warnings']
+
+    if force is True or ret_obj['data'] != {}:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True, warnings=warnings)
+        else:
+            ret_obj['data'] = ret_obj['data']
+            uuid = ret_obj['data']['uuid']
+            return isvgAppliance.invoke_delete(
+                "Un-configure identity data store", "{0}/{1}".format(uri, uuid), warnings=warnings)
+
+    return isvgAppliance.create_return_object(warnings=warnings)
+
+
+def update(isvgAppliance, name, hostName, port, dbName, adminName, adminPwd, userName, userPwd, configuredAs, retryInterval, maximumRetries, existingDB, oracleSvce, oracleLocationName, dropTables, useSSL, altServerNames, altPortNumbers, connTimeOut, maxConn, minConn, reapTime, agedTimeout, unusedTimeout, check_mode=False, force=False):
+    """
+    Updating identity data store
+    """
+    ret_obj = get(isvgAppliance)
+    warnings = ret_obj['warnings']
+
+    # JSON payload of interest is at first (and only) position of array
+    ret_obj['data'] = ret_obj['data'][0]
+
+    uuid = ret_obj['data']['uuid']    
+
+    needs_update = False
+
+    # Create a simple json with just the attributes
+    json_data = {
+        "name": name,
+        "uuid": uuid
+    }
+   
+    if 'action' in ret_obj['data']:
+        del ret_obj['data']['action']
+    if 'lastmodified' in ret_obj['data']:
+        del ret_obj['data']['lastmodified']
+    if 'certCheckSum' in ret_obj['data']:
+        del ret_obj['data']['certCheckSum']
+    
+    # mandatory attributes
+    if hostName is not None:
+        json_data['hostName'] = hostName
+    elif 'hostName' in ret_obj['data']:
+        if ret_obj['data']['hostName'] is not None:
+            json_data['hostName'] = ret_obj['data']['hostName']
+        else:
+            del ret_obj['data']['hostName']
+    if port is not None:
+        json_data['port'] = port
+    elif 'port' in ret_obj['data']:
+        if ret_obj['data']['port'] is not None:
+            json_data['port'] = ret_obj['data']['port']
+        else:
+            del ret_obj['data']['port']
+    if dbName is not None:
+        json_data['dbName'] = dbName
+    elif 'dbName' in ret_obj['data']:
+        if ret_obj['data']['dbName'] is not None:
+            json_data['dbName'] = ret_obj['data']['dbName']
+        else:
+            del ret_obj['data']['dbName']
+    if adminName is not None:
+        json_data['adminName'] = adminName
+    elif 'adminName' in ret_obj['data']:
+        if ret_obj['data']['adminName'] is not None:
+            json_data['adminName'] = ret_obj['data']['adminName']
+        else:
+            del ret_obj['data']['adminName']
+    if adminPwd is not None:
+        json_data['adminPwd'] = adminPwd
+    elif 'adminPwd' in ret_obj['data']:
+        if ret_obj['data']['adminPwd'] is not None:
+            json_data['adminPwd'] = ret_obj['data']['adminPwd']
+        else:
+            del ret_obj['data']['adminPwd']
+    if userName is not None:
+        json_data['userName'] = userName
+    elif 'userName' in ret_obj['data']:
+        if ret_obj['data']['userName'] is not None:
+            json_data['userName'] = ret_obj['data']['userName']
+        else:
+            del ret_obj['data']['userName']
+    if userPwd is not None:
+        json_data['userPwd'] = userPwd
+    elif 'userPwd' in ret_obj['data']:
+        if ret_obj['data']['userPwd'] is not None:
+            json_data['userPwd'] = ret_obj['data']['userPwd']
+        else:
+            del ret_obj['data']['userPwd']
+    if configuredAs is not None:
+        json_data['configuredAs'] = configuredAs
+    elif 'configuredAs' in ret_obj['data']:
+        if ret_obj['data']['configuredAs'] is not None:
+            json_data['configuredAs'] = ret_obj['data']['configuredAs']
+        else:
+            del ret_obj['data']['configuredAs']
+    if retryInterval is not None:
+        json_data['retryInterval'] = retryInterval
+    elif 'retryInterval' in ret_obj['data']:
+        if ret_obj['data']['retryInterval'] is not None:
+            json_data['retryInterval'] = ret_obj['data']['retryInterval']
+        else:
+            del ret_obj['data']['retryInterval']    
+    if maximumRetries is not None:
+        json_data['maximumRetries'] = maximumRetries
+    elif 'maximumRetries' in ret_obj['data']:
+        if ret_obj['data']['maximumRetries'] is not None:
+            json_data['maximumRetries'] = ret_obj['data']['maximumRetries']
+        else:
+            del ret_obj['data']['maximumRetries']    
+    if oracleLocationName is not None:
+        json_data['oracleLocationName'] = oracleLocationName
+    elif 'oracleLocationName' in ret_obj['data']:
+        if ret_obj['data']['oracleLocationName'] is not None:
+            json_data['oracleLocationName'] = ret_obj['data']['oracleLocationName']
+        else:
+            del ret_obj['data']['oracleLocationName']    
+    # optional attributes
+    if dropTables is not None:
+        json_data['dropTables'] = dropTables
+    elif 'dropTables' in ret_obj['data']:
+        if ret_obj['data']['dropTables'] is not None:
+            json_data['dropTables'] = ret_obj['data']['dropTables']
+        else:
+            del ret_obj['data']['dropTables']    
+    if useSSL is not None:
+        json_data['useSSL'] = useSSL
+    elif 'useSSL' in ret_obj['data']:
+        if ret_obj['data']['useSSL'] is not None:
+            json_data['useSSL'] = ret_obj['data']['useSSL']
+        else:
+            del ret_obj['data']['useSSL']    
+    if altServerNames is not None:
+        json_data['altServerNames'] = altServerNames
+    elif 'altServerNames' in ret_obj['data']:
+        if ret_obj['data']['altServerNames'] is not None:
+            json_data['altServerNames'] = ret_obj['data']['altServerNames']
+        else:
+            del ret_obj['data']['altServerNames']    
+    if altPortNumbers is not None:
+        json_data['altPortNumbers'] = altPortNumbers
+    elif 'altPortNumbers' in ret_obj['data']:
+        if ret_obj['data']['altPortNumbers'] is not None:
+            json_data['altPortNumbers'] = ret_obj['data']['altPortNumbers']
+        else:
+            del ret_obj['data']['altPortNumbers']
+    if connTimeOut is not None:
+        json_data['connTimeOut'] = connTimeOut
+    elif 'connTimeOut' in ret_obj['data']:
+        if ret_obj['data']['connTimeOut'] is not None:
+            json_data['connTimeOut'] = ret_obj['data']['connTimeOut']
+        else:
+            del ret_obj['data']['connTimeOut']
+    if maxConn is not None:
+        json_data['maxConn'] = maxConn
+    elif 'maxConn' in ret_obj['data']:
+        if ret_obj['data']['maxConn'] is not None:
+            json_data['maxConn'] = ret_obj['data']['maxConn']
+        else:
+            del ret_obj['data']['maxConn']
+    if minConn is not None:
+        json_data['minConn'] = minConn
+    elif 'minConn' in ret_obj['data']:
+        if ret_obj['data']['minConn'] is not None:
+            json_data['minConn'] = ret_obj['data']['minConn']
+        else:
+            del ret_obj['data']['minConn']
+    if reapTime is not None:
+        json_data['reapTime'] = reapTime
+    elif 'reapTime' in ret_obj['data']:
+        if ret_obj['data']['reapTime'] is not None:
+            json_data['reapTime'] = ret_obj['data']['reapTime']
+        else:
+            del ret_obj['data']['reapTime']
+    if agedTimeout is not None:
+        json_data['agedTimeout'] = agedTimeout
+    elif 'agedTimeout' in ret_obj['data']:
+        if ret_obj['data']['agedTimeout'] is not None:
+            json_data['agedTimeout'] = ret_obj['data']['agedTimeout']
+        else:
+            del ret_obj['data']['agedTimeout']
+    if unusedTimeout is not None:
+        json_data['unusedTimeout'] = unusedTimeout
+    elif 'unusedTimeout' in ret_obj['data']:
+        if ret_obj['data']['unusedTimeout'] is not None:
+            json_data['unusedTimeout'] = ret_obj['data']['unusedTimeout']
+        else:
+            del ret_obj['data']['unusedTimeout']
+
+    sorted_ret_obj = tools.json_sort(ret_obj['data'])
+    sorted_json_data = tools.json_sort(json_data)
+    logger.debug("Sorted Existing Data:{0}".format(sorted_ret_obj))
+    logger.debug("Sorted Desired  Data:{0}".format(sorted_json_data))
+    if sorted_ret_obj != sorted_json_data:
+        json_data['_isNew'] = False
+        json_data['action'] = "reconfigure"
+        if oracleSvce is not None:
+            json_data['oracleSvce'] = oracleSvce
+        if existingDB is not None:
+            json_data['existingDB'] = existingDB
+        needs_update = True
+
+    if force is True or needs_update is True:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True)
+        else:
+            return isvgAppliance.invoke_put(
+                "Update identity data store", "{0}/{1}".format(uri, uuid),
+                json_data, warnings=warnings)
+
+    return isvgAppliance.create_return_object(changed=False)
+
+
+def set(isvgAppliance, name, hostName, port, dbName, adminName, adminPwd, userName, userPwd, configuredAs, retryInterval, maximumRetries, existingDB, oracleSvce, oracleLocationName, dropTables="false", useSSL=False, altServerNames="", altPortNumbers="", connTimeOut=180, maxConn=30, minConn=5, reapTime=180, agedTimeout=0, unusedTimeout=1800, check_mode=False, force=False):
+    """
+    Creating or Modifying a identity data store configuration
+    """
+    if (search(isvgAppliance, name))['data'] == {}:
+        # Force the add - we already know object does not exist
+        logger.info("Identity data store {0} had no match, requesting to configure.".format(name))
+        return add(isvgAppliance, name, hostName, port, dbName, adminName, adminPwd, userName, userPwd, configuredAs, retryInterval, maximumRetries, existingDB, oracleSvce, oracleLocationName, dropTables, useSSL, altServerNames, altPortNumbers, connTimeOut, maxConn, minConn, reapTime, agedTimeout, unusedTimeout, check_mode=check_mode, force=True)
+    else:
+        # Update request
+        logger.info("Identity data store {0} exists, requesting to reconfigure.".format(name))
+        return update(isvgAppliance, name, hostName, port, dbName, adminName, adminPwd, userName, userPwd, configuredAs, retryInterval, maximumRetries, existingDB, oracleSvce, oracleLocationName, dropTables, useSSL, altServerNames, altPortNumbers, connTimeOut, maxConn, minConn, reapTime, agedTimeout, unusedTimeout, check_mode=check_mode, force=force)

--- a/ibmsecurity/isvg/im/external_library.py
+++ b/ibmsecurity/isvg/im/external_library.py
@@ -1,0 +1,123 @@
+import logging
+import hashlib
+from ibmsecurity.utilities import tools
+
+logger = logging.getLogger(__name__)
+
+uri = "/external_library"
+
+
+def get_all(isvgAppliance, check_mode=False, force=False):
+    """
+    Get external library entries
+    """
+    return isvgAppliance.invoke_get("Retrieving external library entries", uri)
+
+
+def search(isvgAppliance, library, check_mode=False, force=False):
+    """
+    Search for existing library by file name
+    """
+    ret_obj = get_all(isvgAppliance)
+    return_obj = isvgAppliance.create_return_object()
+
+    for obj in ret_obj['data']:
+        if 'fileName' in obj and obj['fileName'] == tools.path_leaf(library):
+            logger.info("Found library entry: {0}".format(obj['fileName']))
+            return_obj['data'] = obj
+            return_obj['rc'] = 0
+            break
+
+    return return_obj
+    
+
+def upload(isvgAppliance, library, check_mode=False, force=False):
+    """
+    Import external library
+    """
+    warnings = []
+
+    if force is True or not _check(isvgAppliance, library):
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True, warnings=warnings)
+        else:
+            file_short = tools.path_leaf(library);
+            ret_obj = isvgAppliance.invoke_post_files(
+                "Import external library",
+                "/upload_object/" + file_short,
+                [
+                    {
+                        'file_formfield': 'uploadedfile',
+                        'filename': library,
+                        'mimetype': 'application/octet-stream'
+                    }
+                ],
+                {
+                    'fileName': file_short,
+                    'upload_file_type': 'library'
+                },
+                json_response=False)
+
+            warnings = ret_obj['warnings']
+
+            if ret_obj["rc"] == 0:
+                library_json = {
+                   "fileName": file_short,
+                   "isWorkflowExtension": "false",
+                   "extensionFile": "",
+                   "isLibrary": True,
+                   "action":"configure",
+                   "_isNew": True,
+                   "uploadedfile":[
+                      {
+                         "index":0,
+                         "name": file_short,
+                         "type": ""
+                      }
+                   ]
+                }
+
+                return isvgAppliance.invoke_post(
+                    "Save external library metadata", uri, library_json, warnings=warnings)
+
+    return isvgAppliance.create_return_object()
+
+
+def delete(isvgAppliance, library, check_mode=False, force=False):
+    """
+    Delete an existing external library
+    """
+    warnings = []
+    
+    ret_obj = search(isvgAppliance, library, check_mode=check_mode, force=force)
+
+    if force is True or ret_obj['data'] != {}:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True, warnings=warnings)
+        else:
+            if 'uuid' in ret_obj['data']:
+                uuid = ret_obj['data']['uuid']
+                warnings = ret_obj['warnings']
+                return isvgAppliance.invoke_delete(
+                    "Delete an existing external library", "{0}/{1}".format(uri, uuid), warnings=warnings)
+
+    return isvgAppliance.create_return_object(warnings=warnings)
+
+
+def _check(isvgAppliance, library):
+    """
+    Check if external library needs to be uploaded
+    """
+    ret_obj = search(isvgAppliance, library)
+
+    if len(ret_obj['data']) > 0 and 'checkSum' in ret_obj['data']:
+        applianceCheckSum = ret_obj['data']['checkSum']
+        with open(library, "rb") as f:
+            bytes = f.read()
+        localCheckSum = hashlib.sha256(bytes).hexdigest()
+        if applianceCheckSum == localCheckSum:
+            return True
+        else:
+            return False
+    else:
+        return False

--- a/ibmsecurity/isvg/im/guided_setup.py
+++ b/ibmsecurity/isvg/im/guided_setup.py
@@ -1,0 +1,33 @@
+import logging
+import ibmsecurity.utilities.tools
+
+logger = logging.getLogger(__name__)
+
+uri = "/setup_complete_guided"
+
+def get(isvgAppliance, check_mode=False, force=False):
+    """
+    Get Set up complete status
+    """
+    return isvgAppliance.invoke_get("Get Setup Complete Settings", "/")
+
+
+def complete(isvgAppliance, check_mode=False, force=False):
+    """
+    Setup complete
+    """
+    if force is False:
+        ret_obj = get(isvgAppliance)
+
+    #
+    # if the guided setup is complete, fetching data at '/' will return non-empty JSON payload
+    if force is True or len(ret_obj['data']) == 0:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True)
+        else:
+            return isvgAppliance.invoke_post(
+                "Setup complete",
+                uri,
+                {})
+
+    return isvgAppliance.create_return_object()

--- a/ibmsecurity/isvg/im/jvm_property.py
+++ b/ibmsecurity/isvg/im/jvm_property.py
@@ -1,0 +1,119 @@
+import logging
+from ibmsecurity.utilities import tools
+
+logger = logging.getLogger(__name__)
+
+# URI for this module
+uri = "/jvm_property"
+
+
+def get_all(isvgAppliance, check_mode=False, force=False):
+    """
+    Retrieve all property/value pairs
+    """
+    return isvgAppliance.invoke_get("Retrieve all property/value pair", "{0}".format(uri))
+
+
+def get(isvgAppliance,  propertyName, check_mode=False, force=False):
+    """
+    Retrieve specific property/value pair
+    """
+    return isvgAppliance.invoke_get("Retrieve a specific property/value pair", "{0}?propertyName={1}".format(uri, propertyName))
+
+
+def search(isvgAppliance, propertyName, check_mode=False, force=False):
+    """
+    Search for existing property/value pair for a given file. 
+    Just care for presence of property, not its actual value.
+    """
+    ret_obj = get(isvgAppliance, propertyName)
+    return_obj = isvgAppliance.create_return_object()
+
+    for obj in ret_obj['data']:
+        if 'Error' not in obj:
+            if obj['propertyName'] == propertyName:
+                logger.info("Found property {0}: {1}".format(propertyName, obj['propertyValue']))
+                return_obj['data'] = obj
+                return_obj['rc'] = 0
+
+    return return_obj
+
+
+def add(isvgAppliance, propertyName, propertyValue, check_mode=False, force=False):
+    """
+    Create an new property/value pair
+    """
+    ret_obj = search(isvgAppliance, propertyName, check_mode=check_mode, force=force)
+    warnings = ret_obj['warnings']
+
+    if force is True or ret_obj['data'] == {}:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True, warnings=warnings)
+        else:
+            # Create a simple json with just the property/value pair
+            property_json = {
+                "propertyName": propertyName,
+                "propertyValue": propertyValue
+            }
+
+            return isvgAppliance.invoke_post(
+                "Create a new property/value pair", uri, property_json, warnings=warnings)
+
+    return isvgAppliance.create_return_object(warnings=warnings)
+
+
+def delete(isvgAppliance, propertyName, check_mode=False, force=False):
+    """
+    Delete a property/value pair
+    """
+    ret_obj = search(isvgAppliance, propertyName, check_mode=check_mode, force=force)
+    if force is True or ret_obj['data'] != {}:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True, warnings=warnings)
+        else:
+            return isvgAppliance.invoke_delete(
+                "Delete a property/value pair", "{0}?propertyName={1}".format(uri, propertyName), warnings=warnings)
+
+    return isvgAppliance.create_return_object(warnings=warnings)
+
+
+def update(isvgAppliance, propertyName, propertyValue, check_mode=False, force=False):
+    """
+    Update a property/value pair
+    """
+    ret_obj = search(isvgAppliance, propertyName, check_mode=check_mode, force=force)
+    warnings = ret_obj['warnings']
+
+    needs_update = True
+    if 'propertyName' in ret_obj['data']:
+        if ret_obj['data']['propertyName'] == propertyName and ret_obj['data']['propertyValue'] == propertyValue:
+            needs_update = False
+
+    if force is True or needs_update is True:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True, warnings=warnings)
+        else:
+            # Create a simple json with just the property/value pair
+            property_json = {
+                "propertyName": propertyName,
+                "propertyValue": propertyValue
+            }
+
+            return isvgAppliance.invoke_put(
+                "Update an existing property/value pair", uri, property_json, warnings=warnings)
+
+    return isvgAppliance.create_return_object(warnings=warnings)
+
+
+def set(isvgAppliance, propertyName, propertyValue, check_mode=False, force=False):
+    """
+    Creating or Modifying a property/value pair
+    """
+    if (search(isvgAppliance, propertyName))['data'] == {}:
+        # Force the add - we already know object does not exist
+        logger.info("Property {0} had no match, requesting to add new one.".format(propertyName))
+        return add(isvgAppliance, propertyName, propertyValue, check_mode=check_mode, force=True)
+    else:
+        # Update request
+        logger.info("Property {0} exists, requesting to update.".format(propertyName))
+        return update(isvgAppliance, propertyName, propertyValue, check_mode=check_mode, force=force)

--- a/ibmsecurity/isvg/im/keystore.py
+++ b/ibmsecurity/isvg/im/keystore.py
@@ -1,0 +1,109 @@
+import logging
+import json
+import tempfile
+from ibmsecurity.utilities import tools
+
+logger = logging.getLogger(__name__)
+
+uri = "/custfile_mgmt"
+
+
+def get(isvgAppliance, check_mode=False, force=False):
+    """
+    Get keystore info
+    """
+    return isvgAppliance.invoke_get("Retrieving keystore entries", uri + "/data")
+
+
+def search(isvgAppliance, keystore="itimKeystore.jceks", check_mode=False, force=False):
+    """
+    Search for existing library by file name
+    """
+    ret_obj = get(isvgAppliance)
+
+    return_obj = isvgAppliance.create_return_object()
+
+    if 'children' in ret_obj['data']:
+        for child in ret_obj['data']['children']:
+            if 'fileName' in child and child['fileName'] == 'keystore':
+                files=json.loads(child['files'])
+                for file in files:
+                    if 'fileName' in file and file['fileName'] == keystore:
+                        logger.info("Found keystore entry: {0}".format(file['fileName']))
+                        return_obj['data'] = file
+                        return_obj['rc'] = 0
+                        break
+
+    return return_obj
+    
+
+def upload(isvgAppliance, keystore, check_mode=False, force=False):
+    """
+    Import keystore
+    """
+    warnings = []
+
+    if force is True or not _check(isvgAppliance, keystore):
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True, warnings=warnings)
+        else:
+            ret_obj = isvgAppliance.invoke_post_files(
+                "Import keystore",
+                "/upload_object",
+                [
+                    {
+                        'file_formfield': 'uploadedfile',
+                        'filename': keystore,
+                        'mimetype': 'application/octet-stream'
+                    }
+                ],
+                {
+                    'fileName': tools.path_leaf(keystore),
+                    'upload_file_type': 'custfile'
+                },
+                json_response=False)
+
+            warnings = ret_obj['warnings']
+
+            if ret_obj["rc"] == 0:
+                keystore_json = {
+                   "fileName": "itimKeystore.jceks",
+                   "filePath": "data/keystore",
+                   "ObjType": "externalfile"
+                }
+
+                return isvgAppliance.invoke_post(
+                    "Save keystore metadata", uri, keystore_json, warnings=warnings)
+
+    return isvgAppliance.create_return_object()
+
+
+def download(isvgAppliance, filename, check_mode=False, force=False):
+    """
+    Download keystore
+    """
+    import os.path
+
+    if force is True or (os.path.exists(filename) is False):
+        if check_mode is False:  # No point downloading a file if in check_mode
+            return isvgAppliance.invoke_get_file("Downloading IM keystore",
+                                                 "{0}/{1}?data/keystore/{2}".format(uri, "download", "itimKeystore.jceks"), filename=filename, mime_types="*/*")
+
+    return isvgAppliance.create_return_object()
+
+
+def _check(isvgAppliance, keystore):
+    """
+    Check if keystore needs to be uploaded
+    Need to download current keystore in order to compare both
+    """
+    ret_obj = search(isvgAppliance, tools.path_leaf(keystore))
+
+    if len(ret_obj['data']) > 0:
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            tmpFile = tmpdirname + "/" + tools.path_leaf(keystore)
+            ret_obj = download(isvgAppliance, tmpFile)
+            if ret_obj["rc"] == 0:
+                return tools.files_same(keystore, tmpFile)
+    else:
+        return False

--- a/ibmsecurity/isvg/im/ldap.py
+++ b/ibmsecurity/isvg/im/ldap.py
@@ -1,0 +1,205 @@
+import logging
+from ibmsecurity.utilities import tools
+
+logger = logging.getLogger(__name__)
+
+# URI for this module
+uri = "/ldap_object"
+
+
+def get(isvgAppliance, check_mode=False, force=False):
+    """
+    Retrieve identity user registry configuration
+    """
+    return isvgAppliance.invoke_get("Retrieve identity user registry configuration entries", "{0}".format(uri))
+
+
+def search(isvgAppliance, name, check_mode=False, force=False):
+    """
+    Search for existing identity user registry configuration.
+    """
+    ret_obj = get(isvgAppliance)
+    return_obj = isvgAppliance.create_return_object()
+
+    for obj in ret_obj['data']:
+        if 'name' in obj and obj['name'] == name:
+            logger.info("Found db entry: {0}".format(obj['name']))
+            return_obj['data'] = obj
+            return_obj['rc'] = 0
+
+    return return_obj
+
+
+def add(isvgAppliance, hostName, port, bindDN, bindPwd, orgName, shortOrgName, dnLocation, existingLDAP, useSSL, check_mode=False, force=False):
+    """
+    Updating identity user registry configuration
+    """
+    if force is True:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True)
+        else:
+            if existingLDAP == ['true']:
+                # Reconfiguration does not update the database schema. It configures only the Identity Manager database details.
+                action = "reconfigure"
+            else:
+                # Configuration updates the database schema, in addition it configures the Identity Manager database details.
+                action = "configure"
+
+            return isvgAppliance.invoke_post(
+                "Configure identity data store", "{0}".format(uri),
+                    {
+                      "name": "Identity User Registry",
+                      "hostName": hostName,
+                      "port": port,
+                      "bindDN": bindDN,
+                      "bindPwd": bindPwd, 
+                      "orgName": orgName,
+                      "shortOrgName": shortOrgName,
+                      "dnLocation": dnLocation,
+                      "action": action,
+                      "useSSL": useSSL,
+                      "_isNew": True,
+                      "existingLDAP": existingLDAP
+                    })
+
+    return isvgAppliance.create_return_object(changed=False)
+
+
+def delete(isvgAppliance, name, check_mode=False, force=False):
+    """
+    Un-configure identity data store
+    """
+    ret_obj = search(isvgAppliance, name)
+    warnings = ret_obj['warnings']
+
+    if force is True or ret_obj['data'] != {}:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True, warnings=warnings)
+        else:
+            uuid = ret_obj['data']['uuid']
+            return isvgAppliance.invoke_delete(
+                "Un-configure identity data store", "{0}/{1}".format(uri, uuid), warnings=warnings)
+
+    return isvgAppliance.create_return_object(warnings=warnings)
+
+
+def update(isvgAppliance, hostName, port, bindDN, bindPwd, orgName, shortOrgName, dnLocation, existingLDAP, useSSL, check_mode=False, force=False):
+    """
+    Updating identity data store
+    """
+    ret_obj = get(isvgAppliance)
+    warnings = ret_obj['warnings']
+
+    # JSON payload of interest is at first (and only) position of array
+    ret_obj['data'] = ret_obj['data'][0]
+
+    uuid = ret_obj['data']['uuid']    
+
+    needs_update = False
+
+    # Create a simple json with just the attributes
+    json_data = {
+        "name": "Identity User Registry",
+        "uuid": uuid
+    }
+   
+    if 'action' in ret_obj['data']:
+        del ret_obj['data']['action']
+    if 'lastmodified' in ret_obj['data']:
+        del ret_obj['data']['lastmodified']
+    if 'certCheckSum' in ret_obj['data']:
+        del ret_obj['data']['certCheckSum']
+    
+    # mandatory attributes
+    if hostName is not None:
+        json_data['hostName'] = hostName
+    elif 'hostName' in ret_obj['data']:
+        if ret_obj['data']['hostName'] is not None:
+            json_data['hostName'] = ret_obj['data']['hostName']
+        else:
+            del ret_obj['data']['hostName']
+    if port is not None:
+        json_data['port'] = port
+    elif 'port' in ret_obj['data']:
+        if ret_obj['data']['port'] is not None:
+            json_data['port'] = ret_obj['data']['port']
+        else:
+            del ret_obj['data']['port']
+    if bindDN is not None:
+        json_data['bindDN'] = bindDN
+    elif 'bindDN' in ret_obj['data']:
+        if ret_obj['data']['bindDN'] is not None:
+            json_data['bindDN'] = ret_obj['data']['bindDN']
+        else:
+            del ret_obj['data']['bindDN']
+    if bindPwd is not None:
+        json_data['bindPwd'] = bindPwd
+    elif 'bindPwd' in ret_obj['data']:
+        if ret_obj['data']['bindPwd'] is not None:
+            json_data['bindPwd'] = ret_obj['data']['bindPwd']
+        else:
+            del ret_obj['data']['bindPwd']
+    if orgName is not None:
+        json_data['orgName'] = orgName
+    elif 'orgName' in ret_obj['data']:
+        if ret_obj['data']['orgName'] is not None:
+            json_data['orgName'] = ret_obj['data']['orgName']
+        else:
+            del ret_obj['data']['orgName']
+    if shortOrgName is not None:
+        json_data['shortOrgName'] = shortOrgName
+    elif 'shortOrgName' in ret_obj['data']:
+        if ret_obj['data']['shortOrgName'] is not None:
+            json_data['shortOrgName'] = ret_obj['data']['shortOrgName']
+        else:
+            del ret_obj['data']['shortOrgName']
+    if dnLocation is not None:
+        json_data['dnLocation'] = dnLocation
+    elif 'dnLocation' in ret_obj['data']:
+        if ret_obj['data']['dnLocation'] is not None:
+            json_data['dnLocation'] = ret_obj['data']['dnLocation']
+        else:
+            del ret_obj['data']['dnLocation']
+    if useSSL is not None:
+        json_data['useSSL'] = useSSL
+    elif 'useSSL' in ret_obj['data']:
+        if ret_obj['data']['useSSL'] is not None:
+            json_data['useSSL'] = ret_obj['data']['useSSL']
+        else:
+            del ret_obj['data']['useSSL']    
+
+    sorted_ret_obj = tools.json_sort(ret_obj['data'])
+    sorted_json_data = tools.json_sort(json_data)
+    logger.debug("Sorted Existing Data:{0}".format(sorted_ret_obj))
+    logger.debug("Sorted Desired  Data:{0}".format(sorted_json_data))
+    if sorted_ret_obj != sorted_json_data:
+        json_data['_isNew'] = False
+        json_data['action'] = "reconfigure"
+        if existingLDAP is not None:
+            json_data['existingLDAP'] = existingLDAP
+        needs_update = True
+
+    if force is True or needs_update is True:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True)
+        else:
+            return isvgAppliance.invoke_put(
+                "Update identity data store", "{0}/{1}".format(uri, uuid),
+                json_data, warnings=warnings)
+
+    return isvgAppliance.create_return_object(changed=False)
+
+
+def set(isvgAppliance, hostName, port, bindDN, bindPwd, orgName, shortOrgName, dnLocation, existingLDAP, useSSL=False, check_mode=False, force=False):
+    """
+    Creating or Modifying a identity user registry configuration
+    """
+    name = "Identity User Registry"
+    if (search(isvgAppliance, name))['data'] == {}:
+        # Force the add - we already know object does not exist
+        logger.info("Identity user registry {0} had no match, requesting to configure.".format(name))
+        return add(isvgAppliance, hostName, port, bindDN, bindPwd, orgName, shortOrgName, dnLocation, existingLDAP, useSSL, check_mode=check_mode, force=True)
+    else:
+        # Update request
+        logger.info("Identity user registry {0} exists, requesting to reconfigure.".format(name))
+        return update(isvgAppliance, hostName, port, bindDN, bindPwd, orgName, shortOrgName, dnLocation, existingLDAP, useSSL, check_mode=check_mode, force=force)

--- a/ibmsecurity/isvg/im/mail.py
+++ b/ibmsecurity/isvg/im/mail.py
@@ -1,0 +1,187 @@
+import logging
+from ibmsecurity.utilities import tools
+
+logger = logging.getLogger(__name__)
+
+# URI for this module
+uri = "/mail_object"
+
+
+def get(isvgAppliance, check_mode=False, force=False):
+    """
+    Retrieve mail configuration
+    """
+    return isvgAppliance.invoke_get("Retrieve mail configuration entries", "{0}".format(uri))
+
+
+def search(isvgAppliance, name="Mail Configuration", check_mode=False, force=False):
+    """
+    Search for existing mail configuration.
+    """
+    ret_obj = get(isvgAppliance)
+    return_obj = isvgAppliance.create_return_object()
+
+    for obj in ret_obj['data']:
+        if 'name' in obj and obj['name'] == name:
+            logger.info("Found mail entry: {0}".format(obj['name']))
+            return_obj['data'] = obj
+            return_obj['rc'] = 0
+
+    return return_obj
+
+
+def add(isvgAppliance, mailFrom, mailServer, mailUser, mailPwd, mailBaseUrl, port, useSSL, check_mode=False, force=False):
+    """
+    Updating mail configuration
+    """
+    if force is True:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True)
+        else:
+            return isvgAppliance.invoke_post(
+                "Configure mail configuration", "{0}".format(uri),
+                    {
+                      "mailFrom": mailFrom,
+                      "mailServer": mailServer,
+                      "mailUser": mailUser,
+                      "mailPwd": mailPwd,
+                      "mailBaseUrl": mailBaseUrl,
+                      "name":"Mail Configuration",
+                      "port": port,
+                      "useSSL": useSSL,
+                      "_isNew": True,
+                      "action": "configure"
+                    })
+
+    return isvgAppliance.create_return_object(changed=False)
+
+
+def delete(isvgAppliance, name="Mail Configuration", check_mode=False, force=False):
+    """
+    Un-configure mail configuration
+    """
+    ret_obj = search(isvgAppliance, name)
+    warnings = ret_obj['warnings']
+
+    if force is True or ret_obj['data'] != {}:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True, warnings=warnings)
+        else:
+            ret_obj['data'] = ret_obj['data']
+            uuid = ret_obj['data']['uuid']
+            return isvgAppliance.invoke_delete(
+                "Un-configure mail configuration", "{0}/{1}".format(uri, uuid), warnings=warnings)
+
+    return isvgAppliance.create_return_object(warnings=warnings)
+
+
+def update(isvgAppliance, mailFrom, mailServer, mailUser, mailPwd, mailBaseUrl, port, useSSL, check_mode=False, force=False):
+    """
+    Updating mail configuration
+    """
+    ret_obj = get(isvgAppliance)
+    warnings = ret_obj['warnings']
+
+    # JSON payload of interest is at first (and only) position of array
+    ret_obj['data'] = ret_obj['data'][0]
+
+    uuid = ret_obj['data']['uuid']    
+
+    needs_update = False
+
+    # Create a simple json with just the attributes
+    json_data = {
+        "name": "Mail Configuration",
+        "uuid": uuid
+    }
+   
+    if 'lastModified' in ret_obj['data']:
+        del ret_obj['data']['lastModified']
+    if 'certCheckSum' in ret_obj['data']:
+        del ret_obj['data']['certCheckSum']
+    
+    # mandatory attributes
+    if mailFrom is not None:
+        json_data['mailFrom'] = mailFrom
+    elif 'mailFrom' in ret_obj['data']:
+        if ret_obj['data']['mailFrom'] is not None:
+            json_data['mailFrom'] = ret_obj['data']['mailFrom']
+        else:
+            del ret_obj['data']['mailFrom']
+    if mailServer is not None:
+        json_data['mailServer'] = mailServer
+    elif 'mailServer' in ret_obj['data']:
+        if ret_obj['data']['mailServer'] is not None:
+            json_data['mailServer'] = ret_obj['data']['mailServer']
+        else:
+            del ret_obj['data']['mailServer']
+    if port is not None:
+        json_data['port'] = port
+    elif 'port' in ret_obj['data']:
+        if ret_obj['data']['port'] is not None:
+            json_data['port'] = ret_obj['data']['port']
+        else:
+            del ret_obj['data']['port']
+    if useSSL is not None:
+        json_data['useSSL'] = useSSL
+    elif 'useSSL' in ret_obj['data']:
+        if ret_obj['data']['useSSL'] is not None:
+            json_data['useSSL'] = ret_obj['data']['useSSL']
+        else:
+            del ret_obj['data']['useSSL']
+    # optional attributes
+    if mailUser is not None:
+        json_data['mailUser'] = mailUser
+    elif 'mailUser' in ret_obj['data']:
+        if ret_obj['data']['mailUser'] is not None:
+            json_data['mailUser'] = ret_obj['data']['mailUser']
+        else:
+            del ret_obj['data']['mailUser']
+    if mailPwd is not None:
+        json_data['mailPwd'] = mailPwd
+    elif 'mailPwd' in ret_obj['data']:
+        if ret_obj['data']['mailPwd'] is not None:
+            json_data['mailPwd'] = ret_obj['data']['mailPwd']
+        else:
+            del ret_obj['data']['mailPwd']
+    if mailBaseUrl is not None:
+        json_data['mailBaseUrl'] = mailBaseUrl
+    elif 'mailBaseUrl' in ret_obj['data']:
+        if ret_obj['data']['mailBaseUrl'] is not None:
+            json_data['mailBaseUrl'] = ret_obj['data']['mailBaseUrl']
+        else:
+            del ret_obj['data']['mailBaseUrl']
+
+    sorted_ret_obj = tools.json_sort(ret_obj['data'])
+    sorted_json_data = tools.json_sort(json_data)
+    logger.debug("Sorted Existing Data:{0}".format(sorted_ret_obj))
+    logger.debug("Sorted Desired  Data:{0}".format(sorted_json_data))
+    if sorted_ret_obj != sorted_json_data:
+        json_data['_isNew'] = False
+        json_data['action'] = "reconfigure"
+        needs_update = True
+
+    if force is True or needs_update is True:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True)
+        else:
+            return isvgAppliance.invoke_put(
+                "Update mail configuration", "{0}/{1}".format(uri, uuid),
+                json_data, warnings=warnings)
+
+    return isvgAppliance.create_return_object(changed=False)
+
+
+def set(isvgAppliance, mailFrom, mailServer, mailUser=None, mailPwd=None, mailBaseUrl=None, port=25, useSSL=False, check_mode=False, force=False):
+    """
+    Creating or Modifying a mail configuration
+    """
+    name = "Mail Configuration"
+    if (search(isvgAppliance, name))['data'] == {}:
+        # Force the add - we already know object does not exist
+        logger.info("Mail entry {0} had no match, requesting to configure.".format(name))
+        return add(isvgAppliance, mailFrom, mailServer, mailUser, mailPwd, mailBaseUrl, port, useSSL, check_mode=check_mode, force=True)
+    else:
+        # Update request
+        logger.info("Mail entry {0} exists, requesting to reconfigure.".format(name))
+        return update(isvgAppliance, mailFrom, mailServer, mailUser, mailPwd, mailBaseUrl, port, useSSL, check_mode=check_mode, force=force)

--- a/ibmsecurity/isvg/im/nls.py
+++ b/ibmsecurity/isvg/im/nls.py
@@ -1,0 +1,112 @@
+import logging
+import json
+import tempfile
+from ibmsecurity.utilities import tools
+
+logger = logging.getLogger(__name__)
+
+uri = "/custfile_mgmt"
+
+
+def get_all(isvgAppliance, check_mode=False, force=False):
+    """
+    Get nls property file info
+    """
+    return isvgAppliance.invoke_get("Retrieving nls file entries", uri + "/directories")
+
+
+def search(isvgAppliance, filename, check_mode=False, force=False):
+    """
+    Search for existing nls property by file name
+    """
+    ret_obj = get_all(isvgAppliance)
+
+    return_obj = isvgAppliance.create_return_object()
+
+    if 'children' in ret_obj['data']:
+        for child in ret_obj['data']['children']:
+            if 'fileName' in child and child['fileName'] == 'nls':
+                files=json.loads(child['files'])
+                for file in files:
+                    if 'fileName' in file and file['fileName'] == filename:
+                        logger.info("Found filename entry: {0}".format(file['fileName']))
+                        return_obj['data'] = file
+                        return_obj['rc'] = 0
+                        break
+
+    logger.debug("Found nls entry: {0}".format(return_obj))
+
+    return return_obj
+    
+
+def upload(isvgAppliance, filename, check_mode=False, force=False):
+    """
+    Import nls property file
+    """
+    warnings = []
+
+    if force is True or not _check(isvgAppliance, filename):
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True, warnings=warnings)
+        else:
+            file_short = tools.path_leaf(filename)
+            ret_obj = isvgAppliance.invoke_post_files(
+                "Import nls property",
+                "/upload_object",
+                [
+                    {
+                        'file_formfield': 'uploadedfile',
+                        'filename': filename,
+                        'mimetype': 'text/plain'
+                    }
+                ],
+                {
+                    'fileName': file_short,
+                    'upload_file_type': 'custfile'
+                },
+                json_response=False)
+
+            warnings = ret_obj['warnings']
+
+            if ret_obj["rc"] == 0:
+                nls_json = {
+                   "fileName": file_short,
+                   "filePath": "nls/",
+                   "ObjType": "externalfile"
+                }
+
+                return isvgAppliance.invoke_post(
+                    "Save nls property metadata", uri, nls_json, warnings=warnings)
+
+    return isvgAppliance.create_return_object()
+
+
+def download(isvgAppliance, filename, check_mode=False, force=False):
+    """
+    Download nls property file
+    """
+    import os.path
+
+    if force is True or (os.path.exists(filename) is False):
+        if check_mode is False:  # No point downloading a file if in check_mode
+            return isvgAppliance.invoke_get_file("Downloading nls file",
+                                                 "{0}/{1}?nls/{2}".format(uri, "download", tools.path_leaf(filename)), filename=filename, mime_types="text/html")
+
+    return isvgAppliance.create_return_object()
+
+
+def _check(isvgAppliance, filename):
+    """
+    Check if nls filename needs to be uploaded
+    Need to download current filename in order to compare both
+    """
+    ret_obj = search(isvgAppliance, tools.path_leaf(filename))
+
+    if len(ret_obj['data']) > 0:
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            tmpFile = tmpdirname + "/" + tools.path_leaf(filename)
+            ret_obj = download(isvgAppliance, tmpFile)
+            if ret_obj["rc"] == 0:
+                return tools.files_same(filename, tmpFile)
+    else:
+        return True

--- a/ibmsecurity/isvg/im/openid.py
+++ b/ibmsecurity/isvg/im/openid.py
@@ -43,7 +43,8 @@ def add(isvgAppliance, name, clientID, secret, certAlias, domains, issuerIdentif
             # Create a simple json with just the openid entry
             openid_json = {
                 "name": name,
-                "clientID": secret,
+                "clientID": clientID,
+                "secret": secret,
                 "certAlias": certAlias,
                 "domains": domains,
                 "issuerIdentifier": issuerIdentifier,
@@ -56,7 +57,8 @@ def add(isvgAppliance, name, clientID, secret, certAlias, domains, issuerIdentif
                 "discoveryUrl": discoveryUrl,
                 "advanced": advanced,
                 "signAlgorithm": signAlgorithm,
-                "scope": scope
+                "scope": scope,
+                "userIDToCreateSubject": userIDToCreateSubject
             }
 
             return isvgAppliance.invoke_post(

--- a/ibmsecurity/isvg/im/openid.py
+++ b/ibmsecurity/isvg/im/openid.py
@@ -1,0 +1,245 @@
+import logging
+from ibmsecurity.utilities import tools
+
+logger = logging.getLogger(__name__)
+
+# URI for this module
+uri = "/openid"
+
+
+def get_all(isvgAppliance, check_mode=False, force=False):
+    """
+    Retrieve all openid entries
+    """
+    return isvgAppliance.invoke_get("Retrieve all openid entries", "{0}".format(uri))
+
+
+def search(isvgAppliance, name, check_mode=False, force=False):
+    """
+    Search for existing openid. 
+    Just care for presence of openid, not its actual value.
+    """
+    ret_obj = get_all(isvgAppliance)
+    return_obj = isvgAppliance.create_return_object()
+
+    for obj in ret_obj['data']:
+        if obj['name'] == name:
+            logger.info("Found openid entry {0}".format(name))
+            return_obj['data'] = obj
+            return_obj['rc'] = 0
+            break
+
+    return return_obj
+
+
+def add(isvgAppliance, name, clientID, secret, certAlias, domains, issuerIdentifier, redirectToRPHostPort, userRealm, authUrl, tokenUrl, jwkUrl, logoffUrl, discoveryUrl, advanced, signAlgorithm, userIDToCreateSubject, scope, check_mode=False, force=False):
+    """
+    Create an openid entry
+    """
+    if force is True:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True)
+        else:
+            # Create a simple json with just the openid entry
+            openid_json = {
+                "name": name,
+                "clientID": secret,
+                "certAlias": certAlias,
+                "domains": domains,
+                "issuerIdentifier": issuerIdentifier,
+                "redirectToRPHostPort": redirectToRPHostPort,
+                "userRealm": userRealm,
+                "authUrl": authUrl,
+                "tokenUrl": tokenUrl,
+                "jwkUrl": jwkUrl,
+                "logoffUrl": logoffUrl,
+                "discoveryUrl": discoveryUrl,
+                "advanced": advanced,
+                "signAlgorithm": signAlgorithm,
+                "scope": scope
+            }
+
+            return isvgAppliance.invoke_post(
+                "Create a new openid entry", uri, openid_json)
+
+    return isvgAppliance.create_return_object(changed=False)
+
+
+def delete(isvgAppliance, name, check_mode=False, force=False):
+    """
+    Delete an openid entry
+    """
+    ret_obj = search(isvgAppliance, name, check_mode=check_mode, force=force)
+    warnings = ret_obj['warnings']
+
+    if force is True or ret_obj['data'] != {}:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True, warnings=warnings)
+        else:
+            uuid = ret_obj['data']['uuid']
+            return isvgAppliance.invoke_delete(
+                "Delete a openid entry", "{0}/{1}".format(uri, uuid), warnings=warnings)
+
+    return isvgAppliance.create_return_object(warnings=warnings)
+
+
+def update(isvgAppliance, name, clientID, secret, certAlias, domains, issuerIdentifier, redirectToRPHostPort, userRealm, authUrl, tokenUrl, jwkUrl, logoffUrl, discoveryUrl, advanced, signAlgorithm, userIDToCreateSubject, scope, check_mode=False, force=False):
+    """
+    Updating an openid entry
+    """
+    ret_obj = search(isvgAppliance, name, check_mode=check_mode, force=force)
+    warnings = ret_obj['warnings']
+
+    uuid = ret_obj['data']['uuid']    
+
+    needs_update = False
+
+    # Create a simple json with just the attributes
+    json_data = {
+        "name": name,
+        "uuid": uuid
+    }
+
+    if clientID is not None:
+        json_data['clientID'] = clientID
+    elif 'clientID' in ret_obj['data']:
+        if ret_obj['data']['clientID'] is not None:
+            json_data['clientID'] = ret_obj['data']['clientID']
+        else:
+            del ret_obj['data']['clientID']
+    if secret is not None:
+        json_data['secret'] = secret
+    elif 'secret' in ret_obj['data']:
+        if ret_obj['data']['secret'] is not None:
+            json_data['secret'] = ret_obj['data']['secret']
+        else:
+            del ret_obj['data']['secret']
+    if certAlias is not None:
+        json_data['certAlias'] = certAlias
+    elif 'certAlias' in ret_obj['data']:
+        if ret_obj['data']['certAlias'] is not None:
+            json_data['certAlias'] = ret_obj['data']['certAlias']
+        else:
+            del ret_obj['data']['certAlias']
+    if domains is not None:
+        json_data['domains'] = domains
+    elif 'domains' in ret_obj['data']:
+        if ret_obj['data']['domains'] is not None:
+            json_data['domains'] = ret_obj['data']['domains']
+        else:
+            del ret_obj['data']['domains']
+    if issuerIdentifier is not None:
+        json_data['issuerIdentifier'] = issuerIdentifier
+    elif 'issuerIdentifier' in ret_obj['data']:
+        if ret_obj['data']['issuerIdentifier'] is not None:
+            json_data['issuerIdentifier'] = ret_obj['data']['issuerIdentifier']
+        else:
+            del ret_obj['data']['issuerIdentifier']
+    if redirectToRPHostPort is not None:
+        json_data['redirectToRPHostPort'] = redirectToRPHostPort
+    elif 'redirectToRPHostPort' in ret_obj['data']:
+        if ret_obj['data']['redirectToRPHostPort'] is not None:
+            json_data['redirectToRPHostPort'] = ret_obj['data']['redirectToRPHostPort']
+        else:
+            del ret_obj['data']['redirectToRPHostPort']
+    if userRealm is not None:
+        json_data['userRealm'] = userRealm
+    elif 'userRealm' in ret_obj['data']:
+        if ret_obj['data']['userRealm'] is not None:
+            json_data['userRealm'] = ret_obj['data']['userRealm']
+        else:
+            del ret_obj['data']['userRealm']
+    if authUrl is not None:
+        json_data['authUrl'] = authUrl
+    elif 'authUrl' in ret_obj['data']:
+        if ret_obj['data']['authUrl'] is not None:
+            json_data['authUrl'] = ret_obj['data']['authUrl']
+        else:
+            del ret_obj['data']['authUrl']
+    if tokenUrl is not None:
+        json_data['tokenUrl'] = tokenUrl
+    elif 'tokenUrl' in ret_obj['data']:
+        if ret_obj['data']['tokenUrl'] is not None:
+            json_data['tokenUrl'] = ret_obj['data']['tokenUrl']
+        else:
+            del ret_obj['data']['tokenUrl']
+    if logoffUrl is not None:
+        json_data['logoffUrl'] = logoffUrl
+    elif 'logoffUrl' in ret_obj['data']:
+        if ret_obj['data']['logoffUrl'] is not None:
+            json_data['logoffUrl'] = ret_obj['data']['logoffUrl']
+        else:
+            del ret_obj['data']['logoffUrl']
+    if jwkUrl is not None:
+        json_data['jwkUrl'] = jwkUrl
+    elif 'jwkUrl' in ret_obj['data']:
+        if ret_obj['data']['jwkUrl'] is not None:
+            json_data['jwkUrl'] = ret_obj['data']['jwkUrl']
+        else:
+            del ret_obj['data']['jwkUrl']
+    if discoveryUrl is not None:
+        json_data['discoveryUrl'] = discoveryUrl
+    elif 'discoveryUrl' in ret_obj['data']:
+        if ret_obj['data']['discoveryUrl'] is not None:
+            json_data['discoveryUrl'] = ret_obj['data']['discoveryUrl']
+        else:
+            del ret_obj['data']['discoveryUrl']
+    if advanced is not None:
+        json_data['advanced'] = advanced
+    elif 'advanced' in ret_obj['data']:
+        if ret_obj['data']['advanced'] is not None:
+            json_data['advanced'] = ret_obj['data']['advanced']
+        else:
+            del ret_obj['data']['advanced']
+    if signAlgorithm is not None:
+        json_data['signAlgorithm'] = signAlgorithm
+    elif 'signAlgorithm' in ret_obj['data']:
+        if ret_obj['data']['signAlgorithm'] is not None:
+            json_data['signAlgorithm'] = ret_obj['data']['signAlgorithm']
+        else:
+            del ret_obj['data']['signAlgorithm']
+    if userIDToCreateSubject is not None:
+        json_data['userIDToCreateSubject'] = userIDToCreateSubject
+    elif 'userIDToCreateSubject' in ret_obj['data']:
+        if ret_obj['data']['userIDToCreateSubject'] is not None:
+            json_data['userIDToCreateSubject'] = ret_obj['data']['userIDToCreateSubject']
+        else:
+            del ret_obj['data']['userIDToCreateSubject']
+    if scope is not None:
+        json_data['scope'] = scope
+    elif 'scope' in ret_obj['data']:
+        if ret_obj['data']['scope'] is not None:
+            json_data['scope'] = ret_obj['data']['scope']
+        else:
+            del ret_obj['data']['scope']
+
+    sorted_ret_obj = tools.json_sort(ret_obj['data'])
+    sorted_json_data = tools.json_sort(json_data)
+    logger.debug("Sorted Existing Data:{0}".format(sorted_ret_obj))
+    logger.debug("Sorted Desired  Data:{0}".format(sorted_json_data))
+    if sorted_ret_obj != sorted_json_data:
+        needs_update = True
+
+    if force is True or needs_update is True:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True, warnings=warnings)
+        else:
+            return isvgAppliance.invoke_put(
+                "Update an existing openid entry", "{0}/{1}".format(uri, uuid), 
+                json_data, warnings=warnings)
+
+    return isvgAppliance.create_return_object(warnings=warnings)
+
+
+def set(isvgAppliance, name, clientID, secret, certAlias, domains, issuerIdentifier, redirectToRPHostPort, userRealm, authUrl, tokenUrl, jwkUrl, logoffUrl, discoveryUrl, advanced, signAlgorithm="HS256", userIDToCreateSubject="sub", scope="openid", check_mode=False, force=False):
+    """
+    Creating or Modifying an openid entry
+    """
+    if (search(isvgAppliance, name))['data'] == {}:
+        # Force the add - we already know object does not exist
+        logger.info("Property {0} had no match, requesting to add new one.".format(name))
+        return add(isvgAppliance, name, clientID, secret, certAlias, domains, issuerIdentifier, redirectToRPHostPort, userRealm, authUrl, tokenUrl, jwkUrl, logoffUrl, discoveryUrl, advanced, signAlgorithm, userIDToCreateSubject, scope, check_mode=check_mode, force=True)
+    else:
+        # Update request
+        logger.info("Property {0} exists, requesting to update.".format(name))
+        return update(isvgAppliance, name, clientID, secret, certAlias, domains, issuerIdentifier, redirectToRPHostPort, userRealm, authUrl, tokenUrl, jwkUrl, logoffUrl, discoveryUrl, advanced, signAlgorithm, userIDToCreateSubject, scope, check_mode=check_mode, force=force)

--- a/ibmsecurity/isvg/im/process.py
+++ b/ibmsecurity/isvg/im/process.py
@@ -1,0 +1,54 @@
+import logging
+from ibmsecurity.utilities import tools
+from ibmsecurity.isvg import notifications
+
+logger = logging.getLogger(__name__)
+
+uri = "/widgets/server"
+
+def get(isvgAppliance, check_mode=False, force=False):
+    """
+    Get Identity Manager server status
+    """
+    return isvgAppliance.invoke_get("Retrieving Identity Manager server status", uri)
+
+
+def execute(isvgAppliance, operation="restart", check_mode=False, force=False):
+    """
+    Execute an operation (start, stop or restart) on Identity Manager server
+    """
+
+    check_value, warnings = _check(isvgAppliance, operation)
+
+    if force is True or check_value is True:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True, warnings=warnings)
+        else:
+            return isvgAppliance.invoke_post(
+                "Executing an operation on Identity Manager server", uri + "/" + operation + "/identitymanager",
+                {
+                    'operation': operation
+                }, warnings=warnings)
+
+    return isvgAppliance.create_return_object(warnings=warnings)
+
+
+def _check(isvgAppliance, operation):
+    """
+    Check if operation needs to be applied to process
+    """
+    ret_obj = notifications.get(isvgAppliance)
+    warnings = ret_obj['warnings']
+
+    if ret_obj['rc'] == 0 and len(ret_obj['data']) > 0 and 'items' in ret_obj['data']:
+        for item in ret_obj['data']['items']:
+            if 'message' in item and item['message'] == 'isim_identity_server_restart_reqd' and operation == "restart":
+                logger.info("Identity Manager server requires a restart")
+                return True,warnings
+    else:
+        logger.info(
+            "Executing {0} on Identity Manager server not required or will not work. Use force if needed.".format(
+                operation))
+        return False,warnings
+
+    return False,warnings

--- a/ibmsecurity/isvg/im/property.py
+++ b/ibmsecurity/isvg/im/property.py
@@ -1,0 +1,158 @@
+import logging
+from ibmsecurity.utilities import tools
+from ibmsecurity.isvg.im import property_file
+
+logger = logging.getLogger(__name__)
+
+# URI for this module
+uri = "/v1/property"
+
+
+def get_all(isvgAppliance, propertyFile, check_mode=False, force=False):
+    """
+    Retrieve all property/value pairs for a given property file
+    """
+    ret_obj = property_file.search(isvgAppliance, propertyFile=propertyFile, check_mode=check_mode, force=force)
+    warnings = ret_obj['warnings']
+
+    if ret_obj['data'] == {}:
+        return isvgAppliance.create_return_object(warnings=warnings)
+    else:
+        return isvgAppliance.invoke_get("Retrieve all property/value pair for a given file", "{0}?PropertyFile={1}".format(uri, propertyFile))
+
+
+def get(isvgAppliance, propertyFile, propertyName, check_mode=False, force=False): 
+    """
+    Retrieve specific property/value pair for a given property file
+    """
+    ret_obj = property_file.search(isvgAppliance, propertyFile, check_mode=check_mode, force=force)
+    warnings = ret_obj['warnings']
+
+    if ret_obj['data'] == {}:
+        warnings.append("Property file {0} had no match.".format(propertyFile))
+        return isvgAppliance.create_return_object(warnings=warnings)
+    else:
+        return isvgAppliance.invoke_get("Retrieve a specific property/value pair for a given file", "{0}?PropertyFile={1}&PropertyName{2}".format(uri, propertyFile, propertyName))
+
+
+def search(isvgAppliance, propertyFile, propertyName, check_mode=False, force=False):
+    """
+    Search for existing property/value pair for a given file. 
+    Just care for presence of property, not its actual value.
+    """
+    ret_obj = get(isvgAppliance, propertyFile=propertyFile, propertyName=propertyName)
+    return_obj = isvgAppliance.create_return_object()
+
+    for obj in ret_obj['data']:
+        if obj['PropertyName'] == propertyName:
+            logger.info("Found property {0}: {1}".format(propertyName, obj['PropertyValue']))
+            return_obj['data'] = obj
+            return_obj['rc'] = 0
+            break
+
+    return return_obj
+
+
+def add(isvgAppliance, propertyFile, propertyName, propertyValue, check_mode=False, force=False):
+    """
+    Create an new property/value pair
+    """
+    ret_obj = property_file.search(isvgAppliance, propertyFile, check_mode=check_mode, force=force)
+    if ret_obj['data'] == {}:
+        warnings = ret_obj['warnings']
+        warnings.append(
+            "Property file {0} is not found. Cannot process request.".format(propertyFile))
+        return isvgAppliance.create_return_object(warnings=warnings)
+
+    ret_obj = search(isvgAppliance, propertyFile, propertyName, check_mode=check_mode, force=force)
+    warnings = ret_obj['warnings']
+
+    if force is True or ret_obj['data'] == {}:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True, warnings=warnings)
+        else:
+            # Create a simple json with just the property/value pair
+            property_json = {
+                "PropertyFile": propertyFile,
+                "PropertyName": propertyName,
+                "PropertyValue": propertyValue
+            }
+
+            return isvgAppliance.invoke_post(
+                "Create a new property/value pair", uri, property_json, warnings=warnings)
+
+    return isvgAppliance.create_return_object(warnings=warnings)
+
+
+def delete(isvgAppliance, propertyFile, propertyName, check_mode=False, force=False):
+    """
+    Delete a property/value pair
+    """
+    ret_obj = property_file.search(isvgAppliance, propertyFile, check_mode=check_mode, force=force)
+    warnings = ret_obj['warnings']
+
+    if ret_obj['data'] == {}:
+        warnings = ret_obj['warnings']
+        warnings.append(
+            "Property file {0} is not found. Cannot process request.".format(propertyFile))
+        return isvgAppliance.create_return_object(warnings=warnings)
+
+    ret_obj = search(isvgAppliance, propertyFile, propertyName, check_mode=check_mode, force=force)
+    if force is True or ret_obj['data'] != {}:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True, warnings=warnings)
+        else:
+            return isvgAppliance.invoke_delete(
+                "Delete a property/value pair", "{0}?PropertyFile={1}&PropertyName{2}".format(uri, propertyFile, propertyName), warnings=warnings)
+
+    return isvgAppliance.create_return_object(warnings=warnings)
+
+
+def update(isvgAppliance, propertyFile, propertyName, propertyValue, check_mode=False, force=False):
+    """
+    Update a property/value pair
+    """
+    ret_obj = property_file.search(isvgAppliance, propertyFile, check_mode=check_mode, force=force)
+    if ret_obj['data'] == {}:
+        warnings = ret_obj['warnings']
+        warnings.append(
+            "Property file {0} is not found. Cannot process request.".format(propertyFile))
+        return isvgAppliance.create_return_object(warnings=warnings)
+
+    ret_obj = search(isvgAppliance, propertyFile, propertyName, check_mode=check_mode, force=force)
+    warnings = ret_obj['warnings']
+
+    needs_update = True
+    if ret_obj['data'] != {}:
+        if ret_obj['data']['PropertyName'] == propertyName and ret_obj['data']['PropertyValue'] == propertyValue:
+            needs_update = False
+
+    if force is True or needs_update is True:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True, warnings=warnings)
+        else:
+            # Create a simple json with just the property/value pair
+            property_json = {
+                "PropertyFile": propertyFile,
+                "PropertyName": propertyName,
+                "PropertyValue": propertyValue
+            }
+
+            return isvgAppliance.invoke_put(
+                "Update an existing property/value pair", uri, property_json, warnings=warnings)
+
+    return isvgAppliance.create_return_object(warnings=warnings)
+
+
+def set(isvgAppliance, propertyFile, propertyName, propertyValue, check_mode=False, force=False):
+    """
+    Creating or Modifying a property/value pair
+    """
+    if (search(isvgAppliance, propertyFile, propertyName))['data'] == {}:
+        # Force the add - we already know object does not exist
+        logger.info("Property {0} had no match, requesting to add new one.".format(propertyName))
+        return add(isvgAppliance, propertyFile, propertyName, propertyValue, check_mode=check_mode, force=True)
+    else:
+        # Update request
+        logger.info("Property {0} exists, requesting to update.".format(propertyName))
+        return update(isvgAppliance, propertyFile, propertyName, propertyValue, check_mode=check_mode, force=force)

--- a/ibmsecurity/isvg/im/property_file.py
+++ b/ibmsecurity/isvg/im/property_file.py
@@ -1,0 +1,34 @@
+import logging
+from ibmsecurity.utilities import tools
+
+logger = logging.getLogger(__name__)
+
+# URI for this module
+uri = "/v1/property/propertyfiles"
+
+
+def get_all(isvgAppliance, check_mode=False, force=False):
+    """
+    Retrieve a list of property files
+    """
+    return isvgAppliance.invoke_get("Retrieve a list of property files", uri)
+
+
+def _get(isvgAppliance, propertyFile):
+    return isvgAppliance.invoke_get("Retrieve properties for a specific file", "{0}/{1}".format(uri, propertyFile))
+
+
+def search(isvgAppliance, propertyFile, check_mode=False, force=False):
+    """
+    Search property file by name
+    """
+    ret_obj = get_all(isvgAppliance)
+    return_obj = isvgAppliance.create_return_object()
+
+    for obj in ret_obj['data']:
+        if obj['PropertyFile'] == propertyFile:
+            logger.info("Found property file {0} type: {1}".format(propertyFile, obj['type']))
+            return_obj['data'] = obj['PropertyFile']
+            return_obj['rc'] = 0
+
+    return return_obj

--- a/ibmsecurity/isvg/im/workflowextension.py
+++ b/ibmsecurity/isvg/im/workflowextension.py
@@ -1,0 +1,137 @@
+import logging
+from ibmsecurity.utilities import tools
+
+logger = logging.getLogger(__name__)
+
+# URI for this module
+uri = "/workflowextension"
+
+
+def get_all(isvgAppliance, check_mode=False, force=False):
+    """
+    Retrieve all extensions
+    """
+    return isvgAppliance.invoke_get("Retrieve all extensions", "{0}".format(uri))
+
+
+def search(isvgAppliance, name, check_mode=False, force=False):
+    """
+    Search for existing extension. 
+    Just care for presence of extension, not its actual content.
+    """
+    ret_obj = get_all(isvgAppliance)
+    return_obj = isvgAppliance.create_return_object()
+
+    for obj in ret_obj['data']:
+        if obj['name'] == name:
+            logger.info("Found extension {0}".format(name))
+            return_obj['data'] = obj
+            return_obj['rc'] = 0
+            break
+
+    return return_obj
+
+
+def add(isvgAppliance, name, extension, check_mode=False, force=False):
+    """
+    Create an new extension
+    For now only support adding extension with the 'Provide XML' method
+    """
+    ret_obj = search(isvgAppliance, name, check_mode=check_mode, force=force)
+    warnings = ret_obj['warnings']
+
+    # extension content must be on a single line
+    content = open(extension).read().replace('\n', '')
+
+    if force is True or ret_obj['data'] == {}:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True, warnings=warnings)
+        else:
+            # Create a simple json with just the extension data
+            extension_json = {
+                "name": name,
+                "servletName": "",
+                "servletDescription": "",
+                "servletClass": "",
+                "urlPattern": "",
+                "loadOnStartup": "0",
+                "mode":"advanced",
+                "extension": content
+            }
+
+            return isvgAppliance.invoke_post(
+                "Create a new extension", uri, extension_json, warnings=warnings)
+
+    return isvgAppliance.create_return_object(warnings=warnings)
+
+
+def delete(isvgAppliance, name, extension, check_mode=False, force=False):
+    """
+    Delete an existing extension
+    """
+    ret_obj = search(isvgAppliance, name, check_mode=check_mode, force=force)
+    if force is True or ret_obj['data'] != {}:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True, warnings=warnings)
+        else:
+            if 'uuid' in ret_obj['data']:
+                uuid = ret_obj['data']['uuid']
+                warnings = ret_obj['warnings']
+                return isvgAppliance.invoke_delete(
+                    "Delete an existing extension", "{0}/{1}".format(uri, uuid), warnings=warnings)
+
+    return isvgAppliance.create_return_object(warnings=warnings)
+
+
+def update(isvgAppliance, name, extension, check_mode=False, force=False):
+    """
+    Update an existing extension
+    For now only support adding extension with the 'Provide XML' method
+    """
+    ret_obj = search(isvgAppliance, name, check_mode=check_mode, force=force)
+    warnings = ret_obj['warnings']
+
+    # extension content must be on a single line
+    content = open(extension).read().replace('\n', '')
+    
+    needs_update = True
+    if ret_obj['data'] != {}:
+        if ret_obj['data']['extension'] == content:
+            needs_update = False
+
+    if force is True or needs_update is True:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True, warnings=warnings)
+        else:
+            if 'uuid' in ret_obj['data']:
+                uuid = ret_obj['data']['uuid']
+                # Create a simple json with just the extension data
+                extension_json = {
+                    "name": name,
+                    "servletName": "",
+                    "servletDescription": "",
+                    "servletClass": "",
+                    "urlPattern": "",
+                    "loadOnStartup": "0",
+                    "mode":"advanced",
+                    "extension": content
+                }
+
+                return isvgAppliance.invoke_put(
+                    "Update an existing extension", "{0}/{1}".format(uri,uuid), extension_json, warnings=warnings)
+
+    return isvgAppliance.create_return_object(warnings=warnings)
+
+
+def set(isvgAppliance, name, extension, check_mode=False, force=False):
+    """
+    Creating or Modifying a extension
+    """
+    if (search(isvgAppliance, name, extension))['data'] == {}:
+        # Force the add - we already know object does not exist
+        logger.info("Extension {0} had no match, requesting to add new one.".format(extension))
+        return add(isvgAppliance, name, extension, check_mode=check_mode, force=True)
+    else:
+        # Update request
+        logger.info("Extension {0} exists, requesting to update.".format(extension))
+        return update(isvgAppliance, name, extension, check_mode=check_mode, force=force)

--- a/ibmsecurity/isvg/interfaces.py
+++ b/ibmsecurity/isvg/interfaces.py
@@ -1,0 +1,53 @@
+import logging
+import ibmsecurity.utilities.tools
+
+logger = logging.getLogger(__name__)
+
+
+def get_all_app(isvgAppliance, check_mode=False, force=False):
+    """
+    Retrieving all application interfaces
+    :rtype: (str, dict)
+    """
+    return isvgAppliance.invoke_get("Retrieving all application interfaces", "/application_interfaces")
+
+
+def add(isvgAppliance, address, netmask, network_type, ipFqdn, gateway, interface="P.1", check_mode=False,
+        force=False):
+    """
+    Adding an address to an application interface
+    """
+    if force is True or _check(isvgAppliance, address, netmask, network_type, ipFqdn, gateway, interface) is False:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True)
+        else:
+            return isvgAppliance.invoke_post(
+                "Configuring address for application interface",
+                "/application_interfaces/" + interface + "/addresses",
+                {
+                    'address': address,
+                    'netmask': netmask,
+                    'type': network_type,
+                    'ipFqdn': ipFqdn,
+                    'gateway': gateway
+                })
+
+    return isvgAppliance.create_return_object()
+
+
+def _check(isvgAppliance, address, netmask, network_type, ipFqdn, gateway, interface, check_mode=False,
+        force=False):
+    """
+    Check whether application interface is configured
+    """
+    check_value = False
+
+    ret_obj = get_all_app(isvgAppliance)
+
+    for intf in ret_obj['data']:
+        if intf['id'] == interface and intf['state'] == "up":
+            logger.warning("Application interface already configured")
+            check_value = True
+            break
+
+    return check_value

--- a/ibmsecurity/isvg/lmi.py
+++ b/ibmsecurity/isvg/lmi.py
@@ -1,0 +1,44 @@
+import logging
+import time
+from ibmsecurity.isvg import notifications
+
+logger = logging.getLogger(__name__)
+
+
+def restart(isvgAppliance, check_mode=False, force=False):
+    """
+    Restart LMI
+    """
+    operation = "restart"
+    check_value, warnings = _check(isvgAppliance, operation)
+
+    if force is True or check_value is True:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True, warnings=warnings)
+        else:
+            return isvgAppliance.invoke_post(
+                "Executing an operation on LMI", "/restarts/restart_server",
+                {
+                    'operation': operation
+                }, warnings=warnings)
+
+
+def _check(isvgAppliance, operation):
+    """
+    Check if operation needs to be applied to LMI
+    """
+    ret_obj = notifications.get(isvgAppliance)
+    warnings = ret_obj['warnings']
+
+    if 'items' in ret_obj['data']:
+        for item in ret_obj['data']['items']:
+            if 'message' in item and item['message'] == 'lmi_restart_reqd' and operation == "restart":
+                logger.info("Identity Manager server requires a restart")
+                return True,warnings
+    else:
+        logger.info(
+            "Executing {0} on LMI not required or will not work. Use force if needed.".format(
+                operation))
+        return False,warnings
+
+    return False,warnings

--- a/ibmsecurity/isvg/lmi_auth.py
+++ b/ibmsecurity/isvg/lmi_auth.py
@@ -1,0 +1,193 @@
+import logging
+from ibmsecurity.utilities import tools
+
+logger = logging.getLogger(__name__)
+
+# URI for this module
+uri = "/lmi_auth"
+
+
+def get(isvgAppliance, check_mode=False, force=False):
+    """
+    Retrieve LMI authentication configuration
+    """
+    return isvgAppliance.invoke_get("Retrieve LMI authentication configuration entries", "{0}".format(uri))
+
+
+def search(isvgAppliance, name="LMI Authentication Registry", check_mode=False, force=False):
+    """
+    Search for existing LMI authentication configuration. 
+    """
+    ret_obj = get(isvgAppliance)
+    return_obj = isvgAppliance.create_return_object()
+
+    for obj in ret_obj['data']:
+        if 'name' in obj and obj['name'] == name:
+            logger.info("Found lmi auth entry: {0}".format(obj['name']))
+            return_obj['data'] = obj
+            return_obj['rc'] = 0
+
+    return return_obj
+
+
+def add(isvgAppliance, hostName, port, dnLocation, userFilter, groupFilter, bindDN, bindPwd, useSSL, check_mode=False, force=False):
+    """
+    Updating LMI authentication configuration
+    """
+    if force is True:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True)
+        else:
+            return isvgAppliance.invoke_post(
+                "Configure LMI authentication", "{0}".format(uri),
+                    {
+                      "hostName": hostName,
+                      "port": port,
+                      "dnLocation": dnLocation,
+                      "userFilter": userFilter,
+                      "groupFilter": groupFilter,
+                      "bindDN": bindDN,
+                      "bindPwd": bindPwd,
+                      "useSSL": useSSL,
+                      "name":"LMI Authentication Registry",
+                      "_isNew": True,
+                      "action": "configure"
+                    })
+
+    return isvgAppliance.create_return_object(changed=False)
+
+
+def delete(isvgAppliance, name="LMI Authentication Registry", check_mode=False, force=False):
+    """
+    Un-configure LMI authentication configuration
+    """
+    ret_obj = search(isvgAppliance, name)
+    warnings = ret_obj["warnings"]
+
+    if force is True or ret_obj['data'] != {}:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True, warnings=warnings)
+        else:
+            ret_obj['data'] = ret_obj['data']
+            uuid = ret_obj['data']['uuid']
+            return isvgAppliance.invoke_delete(
+                "Un-configure LMI authentication", "{0}/{1}".format(uri, uuid), warnings=warnings)
+
+    return isvgAppliance.create_return_object(warnings=warnings)
+
+
+def update(isvgAppliance, hostName, port, dnLocation, userFilter, groupFilter, bindDN, bindPwd, useSSL, check_mode=False, force=False):
+    """
+    Updating LMI authentication configuration
+    """
+    ret_obj = get(isvgAppliance)
+    warnings = ret_obj["warnings"]
+
+    # JSON payload of interest is at first (and only) position of array
+    ret_obj['data'] = ret_obj['data'][0]
+
+    uuid = ret_obj['data']['uuid']    
+
+    needs_update = False
+
+    # Create a simple json with just the attributes
+    json_data = {
+        "name": "LMI Authentication Registry",
+        "uuid": uuid
+    }
+   
+    if 'lastModified' in ret_obj['data']:
+        del ret_obj['data']['lastModified']
+    
+    # mandatory attributes
+    if hostName is not None:
+        json_data['hostName'] = hostName
+    elif 'hostName' in ret_obj['data']:
+        if ret_obj['data']['hostName'] is not None:
+            json_data['hostName'] = ret_obj['data']['hostName']
+        else:
+            del ret_obj['data']['hostName']
+    if port is not None:
+        json_data['port'] = port
+    elif 'port' in ret_obj['data']:
+        if ret_obj['data']['port'] is not None:
+            json_data['port'] = ret_obj['data']['port']
+        else:
+            del ret_obj['data']['port']
+    if dnLocation is not None:
+        json_data['dnLocation'] = dnLocation
+    elif 'dnLocation' in ret_obj['data']:
+        if ret_obj['data']['dnLocation'] is not None:
+            json_data['dnLocation'] = ret_obj['data']['dnLocation']
+        else:
+            del ret_obj['data']['dnLocation']
+    if userFilter is not None:
+        json_data['userFilter'] = userFilter
+    elif 'userFilter' in ret_obj['data']:
+        if ret_obj['data']['userFilter'] is not None:
+            json_data['userFilter'] = ret_obj['data']['userFilter']
+        else:
+            del ret_obj['data']['userFilter']
+    if groupFilter is not None:
+        json_data['groupFilter'] = groupFilter
+    elif 'groupFilter' in ret_obj['data']:
+        if ret_obj['data']['groupFilter'] is not None:
+            json_data['groupFilter'] = ret_obj['data']['groupFilter']
+        else:
+            del ret_obj['data']['groupFilter']
+    if useSSL is not None:
+        json_data['useSSL'] = useSSL
+    elif 'useSSL' in ret_obj['data']:
+        if ret_obj['data']['useSSL'] is not None:
+            json_data['useSSL'] = ret_obj['data']['useSSL']
+        else:
+            del ret_obj['data']['useSSL']
+    # optional attributes
+    if bindDN is not None:
+        json_data['bindDN'] = bindDN
+    elif 'bindDN' in ret_obj['data']:
+        if ret_obj['data']['bindDN'] is not None:
+            json_data['bindDN'] = ret_obj['data']['bindDN']
+        else:
+            del ret_obj['data']['bindDN']
+    if bindPwd is not None:
+        json_data['bindPwd'] = bindPwd
+    elif 'bindPwd' in ret_obj['data']:
+        if ret_obj['data']['bindPwd'] is not None:
+            json_data['bindPwd'] = ret_obj['data']['bindPwd']
+        else:
+            del ret_obj['data']['bindPwd']
+
+    sorted_ret_obj = tools.json_sort(ret_obj['data'])
+    sorted_json_data = tools.json_sort(json_data)
+    logger.debug("Sorted Existing Data:{0}".format(sorted_ret_obj))
+    logger.debug("Sorted Desired  Data:{0}".format(sorted_json_data))
+    if sorted_ret_obj != sorted_json_data:
+        json_data['_isNew'] = False
+        json_data['action'] = "reconfigure"
+        needs_update = True
+
+    if force is True or needs_update is True:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True)
+        else:
+            return isvgAppliance.invoke_put(
+                "Update LMI authentication", "{0}/{1}".format(uri, uuid),
+                json_data, warnings=warnings)
+
+    return isvgAppliance.create_return_object(changed=False)
+
+
+def set(isvgAppliance, hostName, port, dnLocation, userFilter, groupFilter, bindDN=None, bindPwd=None, useSSL=False, check_mode=False, force=False):
+    """
+    Creating or Modifying the LMI authentication configuration
+    """
+    name = "LMI Authentication Registry"
+    if (search(isvgAppliance, name))['data'] == {}:
+        # Force the add - we already know property does not exist
+        logger.info("LMI auth entry {0} had no match, requesting to configure.".format(name))
+        return add(isvgAppliance, hostName, port, dnLocation, userFilter, groupFilter, bindDN, bindPwd, useSSL, check_mode=check_mode, force=True)
+    else:
+        # Update request
+        logger.info("LMI auth entry {0} exists, requesting to reconfigure.".format(name))
+        return update(isvgAppliance, hostName, port, dnLocation, userFilter, groupFilter, bindDN, bindPwd, useSSL, check_mode=check_mode, force=force)

--- a/ibmsecurity/isvg/logs.py
+++ b/ibmsecurity/isvg/logs.py
@@ -1,0 +1,11 @@
+import logging
+import ibmsecurity.utilities.tools
+
+logger = logging.getLogger(__name__)
+
+
+def get_event_log(isvgAppliance, check_mode=False, force=False):
+    """
+    Get Event Log
+    """
+    return isvgAppliance.invoke_get("Retrieving Event Log", "/events/system")

--- a/ibmsecurity/isvg/management_authentication.py
+++ b/ibmsecurity/isvg/management_authentication.py
@@ -1,0 +1,114 @@
+import logging
+import ibmsecurity.utilities.tools
+
+logger = logging.getLogger(__name__)
+
+
+def get(isvgAppliance, check_mode=False, force=False):
+    """
+    Get management authentication
+    """
+    return isvgAppliance.invoke_get("Get management authentication",
+                                    "/lmi_auth/")
+
+
+def set(isvgAppliance,
+        ldap_host=None,
+        ldap_port=None,
+        base_dn=None,
+        admin_group_dn=None,
+        enable_ssl=False,
+        user_attribute='uid',
+        group_member_attribute='member',
+        bind_dn=None,
+        bind_password=None,
+        check_mode=False,
+        force=False):
+    """
+    Set management authentication to remote
+    """
+    warnings = []
+    update_required = False
+    json_data = {
+    }
+    if ldap_host is not None:
+        json_data['ldap_host'] = ldap_host
+    if ldap_port is not None:
+        json_data['ldap_port'] = ldap_port
+    if enable_ssl is not None:
+        json_data['enable_ssl'] = enable_ssl
+    if user_attribute is not None:
+        json_data['user_attribute'] = user_attribute
+    if group_member_attribute is not None:
+        json_data['group_member_attribute'] = group_member_attribute
+    if base_dn is not None:
+        json_data['base_dn'] = base_dn
+    if admin_group_dn is not None:
+        json_data['admin_group_dn'] = admin_group_dn
+    if bind_dn is not None:
+        json_data['bind_dn'] = bind_dn
+    if bind_password is not None:
+        json_data['bind_password'] = bind_password
+    if force is False:
+        if bind_password is not None:
+            warnings.append("Unable to read existing bind password to check idempotency.")
+            update_required = True
+        else:
+            ret_obj = get(isvgAppliance)
+            if 'bind_dn' in ret_obj['data']:
+                if ret_obj['data']['bind_dn'] is None:
+                    del ret_obj['data']['bind_dn']
+            sorted_json_data = ibmsecurity.utilities.tools.json_sort(json_data)
+            logger.debug("Sorted input: {0}".format(sorted_json_data))
+            sorted_ret_obj = ibmsecurity.utilities.tools.json_sort(ret_obj['data'])
+            logger.debug("Sorted existing data: {0}".format(sorted_ret_obj))
+            if sorted_ret_obj != sorted_json_data:
+                logger.info("Changes detected, update needed.")
+                update_required = True
+
+    if force is True or update_required is True:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True, warnings=warnings)
+        else:
+            return isvgAppliance.invoke_put(
+                "Set management authentication to remote",
+                "/lmi_auth/",
+                json_data, warnings=warnings)
+
+    return isvgAppliance.create_return_object()
+
+
+def disable(isvgAppliance, check_mode=False, force=False):
+    """
+    Disable remote management authentication
+    """
+    return set(isvgAppliance=isvgAppliance, ldap_host=None, ldap_port=None, base_dn=None, admin_group_dn=None,
+               enable_ssl=None, user_attribute=None,
+               group_member_attribute=None, bind_dn=None, bind_password=None, check_mode=check_mode,
+               force=force)
+
+
+def test(isvgAppliance, userid, password, check_mode=False, force=False):
+    """
+    Testing the management authentication
+    """
+    ret_obj = isvgAppliance.invoke_post("Testing the management authentication",
+                                        "/lmi_auth/",
+                                           {
+                                            'user': userid,
+                                            'password': password
+                                           }
+                                       )
+    ret_obj['changed'] = False
+
+    return ret_obj
+
+
+def compare(isvgAppliance1, isvgAppliance2):
+    """
+    Compare management authentication settings
+    """
+    ret_obj1 = get(isvgAppliance1)
+    ret_obj2 = get(isvgAppliance2)
+
+    return ibmsecurity.utilities.tools.json_compare(ret_obj1, ret_obj2, deleted_keys=[])

--- a/ibmsecurity/isvg/management_ssl_certificate.py
+++ b/ibmsecurity/isvg/management_ssl_certificate.py
@@ -1,0 +1,72 @@
+import logging
+import ibmsecurity.utilities.tools
+
+logger = logging.getLogger(__name__)
+
+
+#
+# Following code to be adapted for using /custfile_mgmt end-point since there are no
+# /management_ssl_certificate end-point in ISVG.
+#
+def get(isvgAppliance, check_mode=False, force=False):
+    """
+    Get management ssl certificate information
+    """
+    return isvgAppliance.invoke_get("Get management ssl certificate information",
+                                    "/custfile_mgmt/download?certs/lmi.jks")
+
+
+#
+# Following code to be adapted for using /custfile_mgmt end-point since there are no
+# /management_ssl_certificate end-point in ISVG. Needs to be adapter also to rely on
+# JKS format instead of PKCS12
+#
+# Another adaptation is ISVG export simple post body as opposed to multipart upload
+# like in ISAM
+#
+def set(isvgAppliance, certificate, password, check_mode=False, force=False):
+    """
+    Import certificate database
+    """
+    warnings = ["Idempotency not available. Unable to extract existing certificate to compare with provided one."]
+    if force is True or _check(isvgAppliance, certificate, None) is False:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True, warnings=warnings)
+        else:
+#
+#	Create a new method isvgAppliance.invoke_post_file() in isvgAppliance to
+#	support the type of upload method required by /custfile_mgmt end-point that differs from 
+#	other techniques used by other end-point /snapshort, available_updates, ...
+#
+#	Ajust list of post data parameter as required
+#
+            return isvgAppliance.invoke_post_files(
+                "Import certificate database",
+                "/upload_object",
+                [{
+                    'file_formfield': 'uploadedfile',
+                    'filename': certificate,
+                    'mimetype': 'application/octet-stream'
+                }],
+                {}, json_response=False)
+
+    return isvgAppliance.create_return_object()
+
+
+def _check(isvgAppliance, certificate, password):
+    """
+    TODO replace placeholder
+    requires additionally pyOpenSSL to load the p12 and extract the issuer, subject, etc
+    """
+
+    return False
+
+
+def compare(isvgAppliance1, isvgAppliance2):
+    """
+    Compare management authentication settings
+    """
+    ret_obj1 = get(isvgAppliance1)
+    ret_obj2 = get(isvgAppliance2)
+
+    return ibmsecurity.utilities.tools.json_compare(ret_obj1, ret_obj2, deleted_keys=[])

--- a/ibmsecurity/isvg/notifications.py
+++ b/ibmsecurity/isvg/notifications.py
@@ -1,0 +1,12 @@
+import logging
+from ibmsecurity.utilities import tools
+
+logger = logging.getLogger(__name__)
+
+uri = "/widgets/notifications"
+
+def get(isvgAppliance, check_mode=False, force=False):
+    """
+    Get Identity Manager data stores status
+    """
+    return isvgAppliance.invoke_get("Retrieving notifications status", uri)

--- a/ibmsecurity/isvg/sdi/process.py
+++ b/ibmsecurity/isvg/sdi/process.py
@@ -1,0 +1,54 @@
+import logging
+from ibmsecurity.utilities import tools
+from ibmsecurity.isvg import notifications
+
+logger = logging.getLogger(__name__)
+
+uri = "/widgets/server"
+
+def get(isvgAppliance, check_mode=False, force=False):
+    """
+    Get Security Directory Integrator server status
+    """
+    return isvgAppliance.invoke_get("Retrieving Security Directory Integrator server status", uri)
+
+
+def execute(isvgAppliance, operation="restart", check_mode=False, force=False):
+    """
+    Execute an operation (start, stop or restart) on Security Directory Integrator server
+    """
+    check_value, warnings = _check(isvgAppliance, operation)
+
+    if force is True or check_value is True:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True, warnings=warnings)
+        else:
+            return isvgAppliance.invoke_post(
+                "Executing an operation on Security Directory Integrator server", uri + "/" + operation + "/directoryintegrator",
+                {
+                    'operation': operation
+                }, warnings=warnings)
+
+    return isvgAppliance.create_return_object(warnings=warnings)
+
+
+def _check(isvgAppliance, operation):
+    """
+    Check if operation needs to be applied to process
+    """
+    ret_obj = notifications.get(isvgAppliance)
+    warnings = ret_obj['warnings']
+    
+    if ret_obj['rc'] == 0 and len(ret_obj['data']) > 0 and 'items' in ret_obj['data']:
+        for item in ret_obj['data']['items']:
+            # code not tested yet with the right message id
+            if 'message' in item and item['message'] == 'isim_identity_server_restart_reqd' and operation == "restart":
+                logger.info("Security Directory Integrator server requires a restart")
+                return True,warnings
+    else:
+        logger.info(
+            "Executing {0} on Security Directory Integrator server not required or will not work. Use force if needed.".format(
+                operation))
+        return False,warnings
+
+    return False,warnings    

--- a/ibmsecurity/isvg/service_agreement.py
+++ b/ibmsecurity/isvg/service_agreement.py
@@ -1,0 +1,61 @@
+"""
+Explorative implement for un-documented ISVG RESTAPI (not functional as of now)
+Preserved here for the future in case if support (RFE)
+"""
+import logging
+
+logger = logging.getLogger(__name__)
+uri = "/setup_service_agreements"
+
+
+def get(isvgAppliance, check_mode=False, force=False):
+    """
+    Retrieving the service agreement settings
+    """
+    return isvgAppliance.invoke_get("Retrieving the service agreement settings", "/setup_service_agreements/accepted")
+
+
+def set(isvgAppliance, check_mode=False, force=False):
+    """
+    Accept Service Agreement
+    """
+
+    if force is True or _check(isvgAppliance) is False:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True)
+        else:
+            return isvgAppliance.invoke_put(
+                "Accept service agreements",
+                "/setup_service_agreements/accepted",
+                {
+                    "accepted": True
+                })
+
+    return isvgAppliance.create_return_object(changed=False)
+
+
+def get_non_ibm(isvgAppliance, offering, check_mode=False, force=False):
+    """
+    Reading non-IBM the software license agreement terms
+    """
+    return isvgAppliance.invoke_get("Reading non-IBM the software license agreement terms",
+                                    "{0}/non_ibm_text/{1}".format(uri, offering))
+
+
+def get_terms(isvgAppliance, check_mode=False, force=False):
+    """
+    Reading the software license agreement terms
+    """
+    return isvgAppliance.invoke_get("Reading the software license agreement terms", "{0}/".format(uri))
+
+
+def _check(isvgAppliance):
+    ret_obj = get(isvgAppliance)
+
+    rc = False
+
+    if ret_obj['data']['accepted']:
+        logger.info("service agreements already accepted")
+        rc = True
+
+    return rc

--- a/ibmsecurity/isvg/setup_complete.py
+++ b/ibmsecurity/isvg/setup_complete.py
@@ -1,0 +1,35 @@
+"""
+Explorative implement for un-documented ISVG RESTAPI (not functional as of now)
+Preserved here for the future in case if support (RFE)
+"""
+import logging
+import ibmsecurity.utilities.tools
+
+logger = logging.getLogger(__name__)
+
+
+def get(isvgAppliance):
+    """
+    Get Set up complete status
+    """
+    return isvgAppliance.invoke_get("Get Setup Complete Settings",
+                                    "/setup_complete")
+
+
+def set(isvgAppliance, check_mode=False, force=False):
+    """
+    Setup complete
+    """
+    if force is False:
+        ret_obj = get(isvgAppliance)
+
+    if force is True or ret_obj['data'].get('configured') is not True:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True)
+        else:
+            return isvgAppliance.invoke_put(
+                "Setup complete",
+                "/setup_complete",
+                {})
+
+    return isvgAppliance.create_return_object()

--- a/ibmsecurity/isvg/snapshots.py
+++ b/ibmsecurity/isvg/snapshots.py
@@ -1,0 +1,183 @@
+import logging
+import ibmsecurity.utilities.tools
+import os.path
+
+logger = logging.getLogger(__name__)
+
+
+def get(isvgAppliance, check_mode=False, force=False):
+    """
+    Get information on existing snapshots
+    """
+    return isvgAppliance.invoke_get("Retrieving snapshots", "/snapshots")
+
+
+def create(isvgAppliance, comment='', check_mode=False, force=False):
+    """
+    Create a new snapshot
+    """
+    if force is True or _check(isvgAppliance, comment=comment) is False:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True)
+        else:
+            return isvgAppliance.invoke_post("Creating snapshot", "/snapshots",
+                                             {
+                                                 'comment': comment
+                                             })
+
+    return isvgAppliance.create_return_object()
+
+
+def delete(isvgAppliance, id, check_mode=False, force=False):
+    """
+    Delete a snapshot
+    """
+    if force is True or _check(isvgAppliance, id=id) is True:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True)
+        else:
+            return isvgAppliance.invoke_delete("Deleting snapshot", "/snapshots/" + id)
+
+    return isvgAppliance.create_return_object()
+
+
+def modify(isvgAppliance, id, comment, check_mode=False, force=False):
+    """
+    Modify the snapshot comment
+    """
+    if force is True or _check(isvgAppliance, id=id) is True:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True)
+        else:
+            return isvgAppliance.invoke_put("Modifying snapshot", "/snapshots/" + id,
+                                            {
+                                                'comment': comment
+                                            })
+
+    return isvgAppliance.create_return_object()
+
+
+def apply(isvgAppliance, id, check_mode=False, force=False):
+    """
+    Apply a snapshot
+    """
+    uri = "/snapshots/apply/" + id
+    if force is True or _check(isvgAppliance, id=id) is True:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True)
+        else:
+            return isvgAppliance.invoke_post("Applying snapshot", uri,
+                                             {"authenticity_token": "KRVlgWbaS4GCOxfZcw+hkrPH2fVB1Vi+k8cayf0y9T4"})
+
+    return isvgAppliance.create_return_object()
+
+
+def download(isvgAppliance, filename, id, check_mode=False, force=False):
+    """
+    Download one snapshot file to a zip file.
+    TODO: Can handle multiple id's - but rest of logic deals with just one for now
+    """
+    if force is True or (_check(isvgAppliance, id=id) is True and os.path.exists(filename) is False):
+        if check_mode is False:  # No point downloading a file if in check_mode
+            uri = "/snapshots/download?record_ids={0}".format(id)
+            return isvgAppliance.invoke_get_file("Downloading snapshots", uri, filename)
+
+    return isvgAppliance.create_return_object()
+
+
+def download_latest(isvgAppliance, dir='.', check_mode=False, force=False):
+    """
+    Download latest snapshot file to a zip file.
+    """
+    ret_obj = get(isvgAppliance)
+
+    # Get snapshot with lowest 'id' value - that will be latest one
+    snaps = min(ret_obj['data'], key=lambda snap: snap['index'])
+    id = snaps['id']
+    file = snaps['filename']
+    filename = os.path.join(dir, file)
+
+    return download(isvgAppliance, filename, id, check_mode, force)
+
+
+def upload(isvgAppliance, filename, check_mode=False, force=False):
+    """
+    Upload snapshot
+    """
+    uri = "/snapshots/upload"
+    if _check(isvgAppliance, fn=filename) is False:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True)
+        else:
+            return isvgAppliance.invoke_post_files(
+                description="Upload snapshot",
+                uri="{0}".format(uri),
+                fileinfo=[{
+                    'file_formfield': 'file',
+                    'filename': filename,
+                    'mimetype': 'application/octet-stream'
+                }],
+                data={},
+                json_response=False)
+
+    return isvgAppliance.create_return_object()
+
+
+def apply_latest(isvgAppliance, check_mode=False, force=False):
+    """
+    Apply latest snapshot file (revert to latest)
+    """
+    ret_obj = get(isvgAppliance)
+
+    # Get snapshot with lowest 'id' value - that will be latest one
+    snaps = min(ret_obj['data'], key=lambda snap: snap['index'])
+    id = snaps['id']
+
+    return apply(isvgAppliance, id, check_mode, force)
+
+
+def compare(isvgAppliance1, isvgAppliance2):
+    """
+    Compare list of snapshots between 2 appliances
+    """
+    ret_obj1 = get(isvgAppliance1)
+    ret_obj2 = get(isvgAppliance2)
+
+    # id of snapshot is uniquely generated on appliance and should therefore be ignored in comparison.
+    # filename of snapshot is generated based on exact date/time and will differ even if 2 snapshots are taken near the
+    # same time. Therefore, filename should be ignored in comparison
+    for snapshot in ret_obj1['data']:
+        del snapshot['id']
+        del snapshot['filename']
+
+    for snapshot in ret_obj2['data']:
+        del snapshot['id']
+        del snapshot['filename']
+
+    return ibmsecurity.utilities.tools.json_compare(ret_obj1, ret_obj2, deleted_keys=['id', 'filename'])
+
+
+def _check(isvgAppliance, comment='', id=None, fn=None):
+    """
+    Check if the last created snapshot has the exact same comment or id exists
+
+    :param isvgAppliance:
+    :param comment:
+    :return:
+    """
+    ret_obj = get(isvgAppliance)
+
+    if id != None:
+        for snaps in ret_obj['data']:
+            if snaps['id'] == id:
+                return True
+    elif fn != None:
+        for snaps in ret_obj['data']:
+            if snaps['filename'] == fn:
+                return True
+    else:
+        for snaps in ret_obj['data']:
+            if comment in snaps['comment']:
+                return True
+
+    return False

--- a/ibmsecurity/isvg/snmp_monitoring.py
+++ b/ibmsecurity/isvg/snmp_monitoring.py
@@ -1,0 +1,143 @@
+import logging
+import ibmsecurity.utilities.tools
+
+logger = logging.getLogger(__name__)
+
+uri = "/snmpd/v1"
+
+
+def get(isvgAppliance, check_mode=False, force=False):
+    """
+    Get SNMP Monitoring v1/2
+    """
+    return isvgAppliance.invoke_get("Get SNMP Monitoring Setup", uri)
+
+
+def set_v1v2(isvgAppliance, community, port=161, check_mode=False, force=False):
+    """
+    Set SNMP Monitoring v1/2
+    """
+    if force is True or _checkv1_2(isvgAppliance, community, port) is False:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True)
+        else:
+            return isvgAppliance.invoke_put(
+                "Updating SNMP Monitoring", uri,
+                {
+                    "snmpv1v2c": {"community": community},
+                    "enabled": True,
+                    "port": port
+                })
+
+    return isvgAppliance.create_return_object()
+
+
+def _checkv1_2(isvgAppliance, community, port):
+    ret_obj = get(isvgAppliance)
+
+    if ret_obj['data'][0]['enabled'] is False:
+        logger.info("SNMP Monitoring is not enabled")
+        return False
+
+    if ret_obj['data'][0]['snmpv1v2c']['community'] != community:
+        logger.info("SNMP Monitoring community is different")
+        return False
+
+    if ret_obj['data'][0]['port'] != port:
+        logger.info("SNMP Monitoring port is different")
+        return False
+
+    return True
+
+
+def set_v3(isvgAppliance, securityLevel, securityUser, authPassword, authProtocol, privacyPassword, privacyProtocol,
+           port=161, check_mode=False, force=False):
+    """
+    Set SNMP Monitoring v3
+    """
+    if force is True or _checkV3(isvgAppliance, securityLevel, securityUser, authPassword, authProtocol,
+                                 privacyPassword, privacyProtocol, port) is False:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True)
+        else:
+            return isvgAppliance.invoke_put(
+                "Updating SNMP Monitoring", uri,
+                {
+                    "snmpv3": {"securityLevel": securityLevel,
+                               "securityUser": securityUser,
+                               "authPassword": authPassword,
+                               "authProtocol": authProtocol,
+                               "privacyPassword": privacyPassword,
+                               "privacyProtocol": privacyProtocol
+                               },
+                    "enabled": True,
+                    "port": port
+                })
+
+    return isvgAppliance.create_return_object()
+
+
+def _checkV3(isvgAppliance, securityLevel, securityUser, authPassword, authProtocol, privacyPassword, privacyProtocol,
+             port):
+    ret_obj = get(isvgAppliance)
+
+    if ret_obj['data'][0]['enabled'] is False:
+        logger.info("SNMP Monitoring is not enabled")
+        return False
+
+    if ret_obj['data'][0]['snmpv3']['securityLevel'] != securityLevel:
+        logger.info("SNMP Monitoring security level is different")
+        return False
+
+    if ret_obj['data'][0]['snmpv3']['securityUser'] != securityUser:
+        logger.info("SNMP Monitoring security user is different")
+        return False
+
+    if ret_obj['data'][0]['snmpv3']['authPassword'] != authPassword:
+        logger.info("SNMP Monitoring auth password is different")
+        return False
+
+    if ret_obj['data'][0]['snmpv3']['authProtocol'] != authProtocol:
+        logger.info("SNMP Monitoring auth protocol is different")
+        return False
+
+    if ret_obj['data'][0]['snmpv3']['privacyPassword'] != privacyPassword:
+        logger.info("SNMP Monitoring privacy password is different")
+        return False
+
+    if ret_obj['data'][0]['snmpv3']['privacyProtocol'] != privacyProtocol:
+        logger.info("SNMP Monitoring privacy protocol is different")
+        return False
+
+    if ret_obj['data'][0]['port'] != port:
+        logger.info("SNMP Monitoring port is different")
+        return False
+
+    return True
+
+
+def disable(isvgAppliance, check_mode=False, force=False):
+    """
+    Disable SNMP Monitoring
+    """
+    if force is False:
+        ret_obj = get(isvgAppliance)
+
+    if force is True or ret_obj['data'][0]['enabled'] is True:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True)
+        else:
+            return isvgAppliance.invoke_put(
+                "Disabling SNMP Monitoring", uri,
+                {
+                    "enabled": False
+                })
+
+    return isvgAppliance.create_return_object()
+
+
+def compare(isvgAppliance1, isvgAppliance2):
+    ret_obj1 = get(isvgAppliance1)
+    ret_obj2 = get(isvgAppliance2)
+
+    return ibmsecurity.utilities.tools.json_compare(ret_obj1, ret_obj2, deleted_keys=[])

--- a/ibmsecurity/isvg/startup.py
+++ b/ibmsecurity/isvg/startup.py
@@ -1,0 +1,12 @@
+import logging
+from ibmsecurity.utilities import tools
+
+logger = logging.getLogger(__name__)
+
+uri = "/startup"
+
+def get(isvgAppliance, check_mode=False, force=False):
+    """
+    Get Identity Manager data stores status
+    """
+    return isvgAppliance.invoke_get("Retrieving startup configuration status", uri)

--- a/ibmsecurity/isvg/support.py
+++ b/ibmsecurity/isvg/support.py
@@ -1,0 +1,141 @@
+import logging
+from ibmsecurity.utilities import tools
+import os.path
+
+logger = logging.getLogger(__name__)
+
+uri = "/support"
+
+
+def get(isvgAppliance, check_mode=False, force=False):
+    """
+    Retrieving information about all valid support files
+    """
+    return isvgAppliance.invoke_get("Retrieving information about all valid support files", uri)
+
+
+def create(isvgAppliance, comment='', check_mode=False, force=False):
+    """
+    Creating a new support file
+    """
+    if force is True or _check(isvgAppliance, comment=comment) is False:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True)
+        else:
+            return isvgAppliance.invoke_post("Creating a new support file", uri,
+                                             {
+                                                 'comment': comment
+                                             })
+
+    return isvgAppliance.create_return_object()
+
+
+def _check(isvgAppliance, comment='', id=None):
+    """
+    Check if the last created support file has the exact same comment or id exists
+
+    :param isvgAppliance:
+    :param comment:
+    :return:
+    """
+    ret_obj = get(isvgAppliance)
+
+    if id != None:
+        for sups in ret_obj['data']:
+            if sups['id'] == id:
+                return True
+    else:
+        for sups in ret_obj['data']:
+            if sups['comment'] == comment:
+                return True
+
+    #       if isinstance(ret_obj['data'], list):
+    #           # check only latest comment
+    #           sup_file = min(ret_obj['data'], key=lambda sup: sup['index'])
+    #           if sup_file['comment'] == comment:
+    #               return True
+
+    return False
+
+
+def delete(isvgAppliance, id, check_mode=False, force=False):
+    """
+    Deleting a support file
+    """
+    if force is True or _check(isvgAppliance, id=id) is True:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True)
+        else:
+            if isinstance(id, list):
+                del_uri = "{0}/multi_destroy{1}".format(uri, tools.create_query_string(record_ids=','.join(id)))
+            else:
+                del_uri = "{0}/{1}".format(uri, id)
+            return isvgAppliance.invoke_delete("Deleting a support file", del_uri)
+
+    return isvgAppliance.create_return_object()
+
+
+def modify(isvgAppliance, id, filename, comment, check_mode=False, force=False):
+    """
+    Modify the snapshot comment
+    """
+    if force is True or _check(isvgAppliance, id=id) is True:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True)
+        else:
+            return isvgAppliance.invoke_put("Modifying snapshot", "{0}/{1}".format(uri, id),
+                                            {
+                                                'id': id,
+                                                'filename': filename,
+                                                'comment': comment
+                                            })
+
+    return isvgAppliance.create_return_object()
+
+
+def download(isvgAppliance, filename, id, check_mode=False, force=False):
+    """
+    Download snapshot file(s) to a zip file.
+    Note: id can be a list or a single value
+    """
+    if force is True or (_check(isvgAppliance, id=id) is True and os.path.exists(filename) is False):
+        if check_mode is False:  # No point downloading a file if in check_mode
+            if isinstance(id, list):
+                id = ','.join(id)
+            uri_download = "{0}/download{1}".format(uri, tools.create_query_string(record_ids=id))
+            return isvgAppliance.invoke_get_file("Downloading snapshots", uri_download, filename)
+
+    return isvgAppliance.create_return_object()
+
+
+def download_latest(isvgAppliance, dir='.', check_mode=False, force=False):
+    """
+    Download latest support file to a zip file.
+    """
+    ret_obj = get(isvgAppliance)
+
+    # Get snapshot with lowest 'id' value - that will be latest one
+    sup_file = min(ret_obj['data'], key=lambda sup: sup['index'])
+    id = sup_file['id']
+    file = sup_file['filename']
+    filename = os.path.join(dir, file)
+
+    return download(isvgAppliance, filename, id, check_mode, force)
+
+
+def compare(isvgAppliance1, isvgAppliance2):
+    """
+    Compare list of support files between 2 appliances - not sure if this will ever be useful?
+    """
+    ret_obj1 = get(isvgAppliance1)
+    ret_obj2 = get(isvgAppliance2)
+
+    for snapshot in ret_obj1['data']:
+        del snapshot['id']
+        del snapshot['filename']
+
+    for snapshot in ret_obj2['data']:
+        del snapshot['id']
+        del snapshot['filename']
+
+    return tools.json_compare(ret_obj1, ret_obj2, deleted_keys=['id', 'filename'])

--- a/ibmsecurity/isvg/system_alerts/alerts.py
+++ b/ibmsecurity/isvg/system_alerts/alerts.py
@@ -1,0 +1,73 @@
+import logging
+import ibmsecurity.utilities.tools
+
+logger = logging.getLogger(__name__)
+
+
+def get(isvgAppliance, check_mode=False, force=False):
+    """
+    Get all snmp objects
+    """
+    return isvgAppliance.invoke_get("Get all alert objects",
+                                    "/system_alerts")
+
+
+def enable(isvgAppliance, uuid, objType, check_mode=False, force=False):
+    """
+    Enable a system alert
+    """
+    if force is True or _check(isvgAppliance, uuid) is False:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True)
+        else:
+            return isvgAppliance.invoke_post(
+                "Enable a system alert",
+                "/system_alerts",
+                {
+                    'uuid': uuid,
+                    'objType': objType
+                })
+
+    return isvgAppliance.create_return_object()
+
+
+def disable(isvgAppliance, uuid, check_mode=False, force=False):
+    """
+    Delete a system alert
+    """
+    if force is True or _check(isvgAppliance, uuid) is True:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True)
+        else:
+            return isvgAppliance.invoke_delete(
+                "Delete a system alert",
+                "/system_alerts/{0}".format(uuid))
+
+    return isvgAppliance.create_return_object()
+
+
+def _check(isvgAppliance, uuid):
+    """
+    Check if the system alert exists or not
+    """
+    ret_obj = get(isvgAppliance)
+    for obj in ret_obj['data']['responses']:
+        if obj['uuid'] == uuid:
+            return True
+
+    return False
+
+
+def compare(isvgAppliance1, isvgAppliance2):
+    """
+    Compare system alert objects between two appliances
+    """
+    ret_obj1 = get(isvgAppliance1)
+    ret_obj2 = get(isvgAppliance2)
+
+    for obj in ret_obj1['data']['responses']:
+        del obj['uuid']
+    for obj in ret_obj2['data']['responses']:
+        del obj['uuid']
+
+    return ibmsecurity.utilities.tools.json_compare(ret_obj1, ret_obj2, deleted_keys=['uuid'])

--- a/ibmsecurity/isvg/system_alerts/rsyslog.py
+++ b/ibmsecurity/isvg/system_alerts/rsyslog.py
@@ -1,0 +1,150 @@
+import logging
+import ibmsecurity.utilities.tools
+
+logger = logging.getLogger(__name__)
+
+
+def get_all(isvgAppliance, check_mode=False, force=False):
+    """
+    Get all rsyslog objects
+    """
+    return isvgAppliance.invoke_get("Get all rsyslog objects",
+                                    "/rsp_rsyslog_objs")
+
+
+def get(isvgAppliance, uuid, check_mode=False, force=False):
+    """
+    Get a specific rsyslog object
+    """
+    return isvgAppliance.invoke_get("Get a specific rsyslog object",
+                                    "/rsp_rsyslog_objs/{0}".format(uuid))
+
+
+def add(isvgAppliance, name, collector, collectorPort=514, collectorLeef=False, objType='rsyslog', comment='',
+        check_mode=False, force=False):
+    """
+    Add a rsyslog object
+    """
+    if force is True or _check(isvgAppliance, None, name, objType, comment, collector, collectorPort,
+                               collectorLeef) is False:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True)
+        else:
+            return isvgAppliance.invoke_post(
+                "Add a rsyslog object",
+                "/rsp_rsyslog_objs/",
+                {
+                    'name': name,
+                    'objType': objType,
+                    'comment': comment,
+                    'collector': collector,
+                    'collectorPort': collectorPort,
+                    'collectorLeef': collectorLeef
+                })
+
+    return isvgAppliance.create_return_object()
+
+
+def update(isvgAppliance, uuid, name, collector, collectorPort=514, collectorLeef=False, objType='rsyslog', comment='',
+           check_mode=False, force=False):
+    """
+    Update a specific rsyslog object
+    """
+    if force is True or (
+            _exists(isvgAppliance, uuid) is True and _check(isvgAppliance, uuid, name, objType, comment,
+                                                            collector, collectorPort, collectorLeef) is False):
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True)
+        else:
+            return isvgAppliance.invoke_put(
+                "Update a specific rsyslog object",
+                "/rsp_rsyslog_objs/{0}".format(uuid),
+                {
+                    'name': name,
+                    'uuid': uuid,
+                    'objType': objType,
+                    'comment': comment,
+                    'collector': collector,
+                    'collectorPort': collectorPort,
+                    'collectorLeef': collectorLeef
+                })
+
+    return isvgAppliance.create_return_object()
+
+
+def delete(isvgAppliance, uuid, check_mode=False, force=False):
+    """
+    Delete a rsyslog object
+    """
+    if force is True or _exists(isvgAppliance, uuid) is True:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True)
+        else:
+            return isvgAppliance.invoke_delete(
+                "Delete a rsyslog object",
+                "/rsp_rsyslog_objs/{0}".format(uuid))
+
+    return isvgAppliance.create_return_object()
+
+
+def _exists(isvgAppliance, uuid):
+    """
+    Check if an uuid object exists
+
+    :param isvgAppliance:
+    :param uuid:
+    :return:
+    """
+    exists = False
+    ret_obj = get_all(isvgAppliance)
+
+    for rsyslog in ret_obj['data']['rsyslogObjects']:
+        if rsyslog['uuid'] == uuid:
+            exists = True
+            break
+
+    return exists
+
+
+def _check(isvgAppliance, uuid, name, objType, comment, collector, collectorPort, collectorLeef):
+    """
+    Check if the rsyslog object exists and is the same - uuid=None means add versus delete
+
+    NOTE: if UUID is not found that will be same as no match!!!
+    """
+
+    set_value = {
+        'name': name,
+        'uuid': uuid,
+        'objType': objType,
+        'comment': comment,
+        'collector': collector,
+        'collectorPort': collectorPort,
+        'collectorLeef': collectorLeef
+    }
+
+    set_value = ibmsecurity.utilities.tools.json_sort(set_value)
+
+    ret_obj = get_all(isvgAppliance)
+    for obj in ret_obj['data']['rsyslogObjects']:
+        if uuid is None and obj['name'] == name:
+            return True
+        elif ibmsecurity.utilities.tools.json_sort(obj) == set_value:
+            return True
+
+    return False
+
+
+def compare(isvgAppliance1, isvgAppliance2):
+    """
+    Compare rsyslog objects between two appliances
+    """
+    ret_obj1 = get_all(isvgAppliance1)
+    ret_obj2 = get_all(isvgAppliance2)
+
+    for obj in ret_obj1['data']['rsyslogObjects']:
+        del obj['uuid']
+    for obj in ret_obj2['data']['rsyslogObjects']:
+        del obj['uuid']
+
+    return ibmsecurity.utilities.tools.json_compare(ret_obj1, ret_obj2, deleted_keys=['uuid'])

--- a/ibmsecurity/isvg/system_alerts/snmp.py
+++ b/ibmsecurity/isvg/system_alerts/snmp.py
@@ -1,0 +1,194 @@
+import logging
+import ibmsecurity.utilities.tools
+
+logger = logging.getLogger(__name__)
+
+
+def get_all(isvgAppliance, check_mode=False, force=False):
+    """
+    Get all snmp objects
+    """
+    return isvgAppliance.invoke_get("Get all snmp objects",
+                                    "/rsp_snmp_objs")
+
+
+def get(isvgAppliance, uuid, check_mode=False, force=False):
+    """
+    Get a specific snmp object
+    """
+    return isvgAppliance.invoke_get("Get a specific snmp object",
+                                    "/rsp_snmp_objs/{0}".format(uuid))
+
+
+def add(isvgAppliance, name, trapAddress, trapCommunity, trapNotificationType=None, trapVersion='V1', trapPort=162,
+        objType='snmp', username=None, authEnabled=None, authType=None, authPassPhrase=None, privEnabled=None,
+        privType=None, privPassPhrase=None, informSnmpEngineID=None, informTimeout=None, comment='', check_mode=False,
+        force=False):
+    """
+    Add a snmp object
+    """
+    if force is True or _check(isvgAppliance, None, name, trapAddress, trapCommunity, trapNotificationType, trapVersion,
+                               trapPort, objType, username, authEnabled, authType, authPassPhrase, privEnabled,
+                               privType, privPassPhrase, informSnmpEngineID, informTimeout, comment) is False:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True)
+        else:
+            return isvgAppliance.invoke_post(
+                "Add a snmp object",
+                "/rsp_snmp_objs/",
+                {
+                    'name': name,
+                    'objType': objType,
+                    'comment': comment,
+                    'trapAddress': trapAddress,
+                    'trapPort': trapPort,
+                    'trapCommunity': trapCommunity,
+                    'trapVersion': trapVersion,
+                    'trapNotificationType': trapNotificationType,
+                    'userName': username,
+                    'authEnabled': authEnabled,
+                    'authType': authType,
+                    'authPassPhrase': authPassPhrase,
+                    'privEnabled': privEnabled,
+                    'privType': privType,
+                    'privPassPhrase': privPassPhrase,
+                    'informSnmpEngineID': informSnmpEngineID,
+                    'informTimeout': informTimeout
+                })
+
+    return isvgAppliance.create_return_object()
+
+
+def update(isvgAppliance, uuid, name, trapAddress, trapCommunity, trapNotificationType=None, trapVersion='V1',
+           trapPort=162, objType='snmp', username=None, authEnabled=None, authType=None, authPassPhrase=None,
+           privEnabled=None, privType=None, privPassPhrase=None, informSnmpEngineID=None, informTimeout=None,
+           comment='', check_mode=False, force=False):
+    """
+    Update a specific snmp object
+    """
+    if force is True or (
+            _exists(isvgAppliance, uuid) is True and _check(isvgAppliance, uuid, name, trapAddress,
+                                                            trapCommunity, trapNotificationType, trapVersion,
+                                                            trapPort, objType, username, authEnabled, authType,
+                                                            authPassPhrase, privEnabled, privType,
+                                                            privPassPhrase, informSnmpEngineID, informTimeout,
+                                                            comment) is False):
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True)
+        else:
+            return isvgAppliance.invoke_put(
+                "Update a specific snmp object",
+                "/rsp_snmp_objs/{0}".format(uuid),
+                {
+                    'name': name,
+                    'uuid': uuid,
+                    'objType': objType,
+                    'comment': comment,
+                    'trapAddress': trapAddress,
+                    'trapPort': trapPort,
+                    'trapCommunity': trapCommunity,
+                    'trapVersion': trapVersion,
+                    'trapNotificationType': trapNotificationType,
+                    'userName': username,
+                    'authEnabled': authEnabled,
+                    'authType': authType,
+                    'authPassPhrase': authPassPhrase,
+                    'privEnabled': privEnabled,
+                    'privType': privType,
+                    'privPassPhrase': privPassPhrase,
+                    'informSnmpEngineID': informSnmpEngineID,
+                    'informTimeout': informTimeout
+                })
+
+    return isvgAppliance.create_return_object()
+
+
+def delete(isvgAppliance, uuid, check_mode=False, force=False):
+    """
+    Delete a snmp object
+    """
+    if force is True or _exists(isvgAppliance, uuid) is True:
+        if check_mode is True:
+            return isvgAppliance.create_return_object(changed=True)
+        else:
+            return isvgAppliance.invoke_delete(
+                "Delete a snmp object",
+                "/rsp_snmp_objs/{0}".format(uuid))
+
+    return isvgAppliance.create_return_object()
+
+
+def _exists(isvgAppliance, uuid):
+    """
+    Check if an uuid object exists
+
+    :param isvgAppliance:
+    :param uuid:
+    :return:
+    """
+    exists = False
+    ret_obj = get_all(isvgAppliance)
+
+    for snmp in ret_obj['data']['snmpObjects']:
+        if snmp['uuid'] == uuid:
+            exists = True
+            break
+
+    return exists
+
+
+def _check(isvgAppliance, uuid, name, trapAddress, trapCommunity, trapNotificationType, trapVersion, trapPort, objType,
+           username, authEnabled, authType, authPassPhrase, privEnabled, privType, privPassPhrase, informSnmpEngineID,
+           informTimeout, comment):
+    """
+    Check if the snmp object exists and is the same - uuid=None means add versus delete
+
+    NOTE: if UUID is not found that will be same as no match!!!
+    """
+
+    set_value = {
+        'name': name,
+        'uuid': uuid,
+        'objType': objType,
+        'comment': comment,
+        'trapAddress': trapAddress,
+        'trapPort': trapPort,
+        'trapCommunity': trapCommunity,
+        'trapVersion': trapVersion,
+        'trapNotificationType': trapNotificationType,
+        'userName': username,
+        'authEnabled': authEnabled,
+        'authType': authType,
+        'authPassPhrase': authPassPhrase,
+        'privEnabled': privEnabled,
+        'privType': privType,
+        'privPassPhrase': privPassPhrase,
+        'informSnmpEngineID': informSnmpEngineID,
+        'informTimeout': informTimeout
+    }
+
+    set_value = ibmsecurity.utilities.tools.json_sort(set_value)
+
+    ret_obj = get_all(isvgAppliance)
+    for obj in ret_obj['data']['snmpObjects']:
+        if uuid is None and obj['name'] == name:
+            return True
+        elif ibmsecurity.utilities.tools.json_sort(obj) == set_value:
+            return True
+
+    return False
+
+
+def compare(isvgAppliance1, isvgAppliance2):
+    """
+    Compare snmp objects between two appliances
+    """
+    ret_obj1 = get_all(isvgAppliance1)
+    ret_obj2 = get_all(isvgAppliance2)
+
+    for obj in ret_obj1['data']['snmpObjects']:
+        del obj['uuid']
+    for obj in ret_obj2['data']['snmpObjects']:
+        del obj['uuid']
+
+    return ibmsecurity.utilities.tools.json_compare(ret_obj1, ret_obj2, deleted_keys=['uuid'])


### PR DESCRIPTION
This first code drop adds support for IBM Security Verify Governance appliances.
Tested only with 10.0.1.0 so far and Python V3.X.

More code will be added in the weeks/months to come as we cover gradually more and more of the appliances features.

There folder structure found in this code drop aims at sorting things between common code and the main platform components:
-Common
-IM (Identity Manager Server)
-CM (Cluster Manager)
-SDI (Security Directory Integrator)

Once this is merged, I will be in position to share the Ansible roles developped for that code drop.

Most of the code in this code drop was based on Appliance's published management RESTAPI documentation, and in some other cases, it had to be extirpated from ISVG Appliance by discovery.

One thing that makes the RESTAPI for ISVG Appliance different is that depending on the configuration state of the appliance, some RESTAPI are too early to call. If you do, the Appliances redirects the user to the /startup URI. So care had to be taken to recognised when it was indeed too early for the RESTAPI endpoints to be invoked.

This code drop does not in any way impact the Python code for ISAM and ISDS.

