### PR TITLE
Bufix: indentation in add method.

### DIFF
--- a/ibmsecurity/isam/web/api_access_control/utilities/credential.py
+++ b/ibmsecurity/isam/web/api_access_control/utilities/credential.py
@@ -27,8 +27,8 @@ def add(isamAppliance, admin_id, admin_pwd, admin_domain="Default", check_mode=F
     if force is True or exist is False:
         if check_mode is True:
             return isamAppliance.create_return_object(changed=True, warnings=warnings)
-    else:
-        return isamAppliance.invoke_post("Store the ISAM administrator credentials",
+        else:
+            return isamAppliance.invoke_post("Store the ISAM administrator credentials",
                                          "{0}".format(uri),
                                          {
                                              'admin_id': admin_id,


### PR DESCRIPTION
The add method in the credential.py contains an indentation error that causes the add to fail if the credential does not exist and force is True.  If the credential does exist, it is updated by the add method which is not the desired behavior.