### PR TITLE
Add id parameter to set and add functions. #376

### DIFF
--- a/ibmsecurity/isam/aac/fido2/relying_parties.py
+++ b/ibmsecurity/isam/aac/fido2/relying_parties.py
@@ -19,8 +19,10 @@ def get_all(isamAppliance, check_mode=False, force=False):
 def get(isamAppliance, name, id=None, check_mode=False, force=False):
     """
     Retrieve a specific FIDO2 Relying Party
+
+    Ignore the id if appliance is less than version 10.0.1
     """
-    if id is None:
+    if id is None or tools.version_compare(isamAppliance.facts['version'], '10.0.1') < 0:
         ret_obj = search(isamAppliance, name=name, check_mode=check_mode, force=force)
         id = ret_obj['data']
 
@@ -83,6 +85,8 @@ def set(isamAppliance, name, rpId, fidoServerOptions, relyingPartyOptions, id=No
 def add(isamAppliance, name, rpId, fidoServerOptions, relyingPartyOptions, id=None, check_mode=False, force=False):
     """
     Create a new FIDO2 Relying Party
+
+    The id parameter is ignored if appliance is less than version 10.0.1
     """
     if force is False:
         ret_obj = search(isamAppliance, name)
@@ -96,7 +100,8 @@ def add(isamAppliance, name, rpId, fidoServerOptions, relyingPartyOptions, id=No
                 "fidoServerOptions": fidoServerOptions,
                 "relyingPartyOptions": relyingPartyOptions
             }
-            if id is not None: json_data["id"] = id
+            if id is not None and tools.version_compare(isamAppliance.facts['version'], '10.0.1') >= 0:
+                json_data["id"] = id
             return isamAppliance.invoke_post(
                 "Create a new FIDO2 relying party", uri, json_data, requires_modules=requires_modules, requires_version=requires_version)
 

--- a/ibmsecurity/isam/aac/fido2/relying_parties.py
+++ b/ibmsecurity/isam/aac/fido2/relying_parties.py
@@ -65,7 +65,7 @@ def delete(isamAppliance, name, check_mode=False, force=False):
 
     return isamAppliance.create_return_object()
 
-def set(isamAppliance, name, rpId, fidoServerOptions, relyingPartyOptions, check_mode=False, force=False):
+def set(isamAppliance, name, rpId, fidoServerOptions, relyingPartyOptions, id=None, check_mode=False, force=False):
     """
     Create or Update a FIDO2 Relying Party
     """
@@ -73,14 +73,14 @@ def set(isamAppliance, name, rpId, fidoServerOptions, relyingPartyOptions, check
         # Force the add - we already know FIDO2 Relying Party does not exist
         logger.info("FIDO2 relying party {0} had no match, requesting to add new one.".format(name))
         return add(isamAppliance, name=name, rpId=rpId, fidoServerOptions=fidoServerOptions, relyingPartyOptions=relyingPartyOptions,
-                   check_mode=check_mode, force=True)
+                   id=id, check_mode=check_mode, force=True)
     else:
         # Update request
         logger.info("FIDO2 relying party {0} exists, requesting to update.".format(name))
         return update(isamAppliance, name=name, rpId=rpId, fidoServerOptions=fidoServerOptions, relyingPartyOptions=relyingPartyOptions,
                       check_mode=check_mode, force=force)
 
-def add(isamAppliance, name, rpId, fidoServerOptions, relyingPartyOptions, check_mode=False, force=False):
+def add(isamAppliance, name, rpId, fidoServerOptions, relyingPartyOptions, id=None, check_mode=False, force=False):
     """
     Create a new FIDO2 Relying Party
     """
@@ -90,14 +90,15 @@ def add(isamAppliance, name, rpId, fidoServerOptions, relyingPartyOptions, check
         if check_mode is True:
             return isamAppliance.create_return_object(changed=True)
         else:
+            json_data = {
+                "name": name,
+                "rpId": rpId,
+                "fidoServerOptions": fidoServerOptions,
+                "relyingPartyOptions": relyingPartyOptions
+            }
+            if id is not None: json_data["id"] = id
             return isamAppliance.invoke_post(
-                "Create a new FIDO2 relying party", uri,
-                {
-                    "name": name,
-                    "rpId": rpId,
-                    "fidoServerOptions": fidoServerOptions,
-                    "relyingPartyOptions": relyingPartyOptions
-                }, requires_modules=requires_modules, requires_version=requires_version)
+                "Create a new FIDO2 relying party", uri, json_data, requires_modules=requires_modules, requires_version=requires_version)
 
     return isamAppliance.create_return_object()
 


### PR DESCRIPTION
Add new optional parameter to set and add functions to allow specifying the Configuration ID when creating a new FIDO2 relyiny party.