### PR TITLE
366 pkcs12 support in pyopenssl is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The following Python Packages are required:
 3. jmespath - is required for sample code
 
 The following Python Packages are optional:
-1. pyOpenSSL - to perform action on certificates (used for idempotency in management_ssl_certificate)
+1. cryptography - to perform action on certificates (used for idempotency in management_ssl_certificate)
 2. python-dateutil - date utilities (used for idempotency in management_ssl_certificate)
 
 Appliances need to have an ip address defined for their LMI. This may mean that appliances have had their initial setup 

--- a/changelog.md
+++ b/changelog.md
@@ -1,14 +1,18 @@
 ---
 # Manual change log
 
-## Build & Deploy
+## Unreleased
 
-- move to pyproject.toml for building 
+- fix: remove pyOpenSSL dependency in management_ssl_certificate.py (#366)
 
 ## 2023.4.25.0
 
 - fix: add id parameter to ibmsecurity/isam/aac/fido2/relying_parties.py (#377)
 - fix: add __init__.py in ibmsecurity/isvg sub folders (#380)
+
+### Build & Deploy
+
+- move to pyproject.toml for building
 
 ## 2023.4.21.0
 

--- a/ibmsecurity/isam/base/management_ssl_certificate.py
+++ b/ibmsecurity/isam/base/management_ssl_certificate.py
@@ -7,8 +7,9 @@ performCertCheck = True
 try:
     from dateutil import parser
     #pip install python-dateutil
-    from OpenSSL.crypto import load_pkcs12, dump_certificate, load_certificate, FILETYPE_PEM
-    # pip install pyOpenSSL
+    import cryptography.hazmat.primitives.serialization.pkcs12
+    import cryptography.x509
+    # pip install cryptography
 except:
     performCertCheck = False
 
@@ -27,7 +28,7 @@ def set(isamAppliance, certificate, password, check_mode=False, force=False):
     Import certificate database
     """
     if not performCertCheck:
-        warnings = ["Idempotency not available. Unable to extract existing certificate to compare with provided one.  Install Python modules python-dateutil and pyOpenSSL."]
+        warnings = ["Idempotency not available. Unable to extract existing certificate to compare with provided one.  Install Python modules python-dateutil and cryptography."]
     else:
         warnings = None
     if force is True or not _check(isamAppliance, certificate, password):
@@ -71,20 +72,19 @@ def _check(isamAppliance, certificate, password):
         currentCert['notafter'] = parser.parse(currentCert['notafter'], ignoretz=True).strftime("%Y-%m-%d")
 
         newCert = {}
-        _type = FILETYPE_PEM
+
         _enc = 'utf-8'
         with open(certificate, 'rb') as f:
             c = f.read()
-        p = load_pkcs12(c, password)
+        password = password.encode()
+        p = cryptography.hazmat.primitives.serialization.pkcs12.load_pkcs12(c, password)
 
-        certificate = p.get_certificate()
-        newCert['subject'] = ",".join(f"{str(name, 'utf-8')}={str(value, 'utf-8')}" for name, value in reversed(certificate.get_subject().get_components()))
+        x509 = p.cert.certificate
+        newCert['subject'] = x509.subject.rfc4514_string()
 
-        x509 = load_certificate(_type, dump_certificate(_type, certificate))
-
-        newCert['issuer'] = ",".join(f"{str(name, _enc)}={str(value, _enc)}" for name, value in reversed(x509.get_issuer().get_components()))
-        newCert['notafter'] = datetime.strptime(str(x509.get_notAfter(), _enc), "%Y%m%d%H%M%SZ").strftime("%Y-%m-%d")
-        newCert['notbefore'] = datetime.strptime(str(x509.get_notBefore(), _enc), "%Y%m%d%H%M%SZ").strftime("%Y-%m-%d")
+        newCert['issuer'] = x509.issuer.rfc4514_string()
+        newCert['notafter'] = x509.not_valid_after.strftime("%Y-%m-%d")
+        newCert['notbefore'] = x509.not_valid_before.strftime("%Y-%m-%d")
 
         curc = json.dumps(currentCert, skipkeys=True, sort_keys=True)
         logger.debug(f"\nSorted Current  Management Cert:\n {curc}\n")
@@ -97,7 +97,7 @@ def _check(isamAppliance, certificate, password):
         else:
             return False
     else:
-        logger.info('Skipping management certificate check because pyOpenSSL or not available.  Install with pip install pyOpenSSL')
+        logger.info('Skipping management certificate idempotency check because cryptography not available.  Install with pip install cryptography')
         return False
 
 

--- a/ibmsecurity/isam/base/management_ssl_certificate.py
+++ b/ibmsecurity/isam/base/management_ssl_certificate.py
@@ -55,7 +55,7 @@ def set(isamAppliance, certificate, password, check_mode=False, force=False):
 
 def _check(isamAppliance, certificate, password):
     """
-    requires additionally pyOpenSSL to load the p12 and extract the issuer, subject, etc
+    requires additionally cryptography to load the p12 and extract the issuer, subject, etc
     Comparing issuer, subject, notafter (date only) and notbefore (date only)
     This DOES NOT check if the certificate is newer , just that it's different from the one that is deployed.
     """


### PR DESCRIPTION
Replace pyOpenSSL with cryptography for idempotency checks in management certificate.

Tested
...
[2023-04-25 17:13:32,388] [PID:1122005 TID:140124998584128] [DEBUG] [ibmsecurity.isam.base.management_ssl_certificate] [_check():90] 
Sorted Current  Management Cert:
 {"issuer": "CN=172.16.73.128,OU=SEL,O=IBM,C=BE", "notafter": "2023-02-25", "notbefore": "2022-02-25", "subject": "CN=172.16.73.128,OU=SEL,O=IBM,C=BE"}

[2023-04-25 17:13:32,388] [PID:1122005 TID:140124998584128] [DEBUG] [ibmsecurity.isam.base.management_ssl_certificate] [_check():93] 
Sorted Desired  Management Cert:
 {"issuer": "CN=172.16.73.128,OU=SEL,O=IBM,C=BE", "notafter": "2023-02-25", "notbefore": "2022-02-25", "subject": "CN=172.16.73.128,OU=SEL,O=IBM,C=BE"}

{'changed': False, 'data': {}, 'rc': 0, 'status_code': 0, 'warnings': []}
...