### PR TITLE
395 ssh keys api lacks proper idempotency

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,8 @@
 # Manual change log
 
 ## Unreleased
-- fix: availabe_updates.py state is no longer available in 10.0.5 or higher, and too many variables in post request
+- fix: available_updates.py state is no longer available in 10.0.5 or higher, and too many variables in post request
+- fix: ssh_keys api added proper idempotency (#395)
 
 ## 2023.7.6.0
 

--- a/ibmsecurity/isam/base/admin_ssh_keys.py
+++ b/ibmsecurity/isam/base/admin_ssh_keys.py
@@ -17,15 +17,15 @@ def get(isamAppliance, uuid, check_mode=False, force=False):
     """
     Get specific ssh public key for the default admin user
     """
-    return isamAppliance.invoke_get("Retrieving key", "/admin_cfg/ssh-keys/{0}/v1".format(uuid))
+    return isamAppliance.invoke_get("Retrieving key", f"/admin_cfg/ssh-keys/{uuid}/v1")
 
 
-def create(isamAppliance, key, name, check_mode=False, force=False):
+def add(isamAppliance, key, name, check_mode=False, force=False):
     """
     Import ssh public key for the default admin user
     """
-    if force is True or _check(isamAppliance) is False:
-        if check_mode is True:
+    if force or not _check(isamAppliance, name):
+        if check_mode:
             return isamAppliance.create_return_object(changed=True, warnings=warnings)
         else:
             return isamAppliance.invoke_post(
@@ -38,22 +38,76 @@ def create(isamAppliance, key, name, check_mode=False, force=False):
 
     return isamAppliance.create_return_object()
 
-
-def _check(isamAppliance, uuid=None):
+create = add
+def update(isamAppliance, key, name, check_mode=False, force=False):
     """
-    Check if the last created key has the exact same uuid or uuid exists
+    Update an existing key
+    """
+    # We know we need to do an update.  The only thing we can verify is that the comment is part
+    update_required = True
+    ret_obj = get(isamAppliance, name)
+    if not ret_obj:
+        # means we cannot find the name
+        logger.debug("Cannot find sshkeys by name")
+        update_required = False
+    elif key:
+        # Extract the comment from the new ssh public key
+        key_comment = key.split(' ')[-1]
+        logger.debug(f"See if {key_comment} for admin exists in a key")
+        if key_comment in ret_obj['data']['fingerprint']:
+            update_required = False
+
+    if check_mode is True:
+        return isamAppliance.create_return_object(changed=True, warnings=warnings)
+    elif update_required:
+        delete(isamAppliance, name)
+        return add(isamAppliance, key, name)
+
+    return isamAppliance.create_return_object()
+
+def set(isamAppliance, key, name, fingerprint=None, check_mode=False, force=False):
+    """
+    Create key if it does not exist yet, update if it does.
+
+    The fingerprint is the output format of ssh-keygen:  `ssh-keygen -l -f ~/.ssh/id_rsa.pub`
+    It is NOT used to send to ISVA, it is used to check if a key already exists.
+    """
+    if not _check(isamAppliance, name, fingerprint):
+        # Force the add - we already know there is no key by this name or fingerprint
+        return add(isamAppliance, key=key, name=name,
+                   check_mode=check_mode, force=True)
+    else:
+        # There is no update.  Let's see what this does.
+        return update(isamAppliance, key=key, name=name, check_mode=check_mode, force=force)
+
+
+def _check(isamAppliance, name=None, fingerprint=None):
+    """
+    The fingerprint is generated from the actual public key, using `ssh-keygen -l -f ~/.ssh/id_rsa.pub`
+    I'm unsure how to do this in Python, but I'm adding it to the check anyway (because Ansible)
+
+    If a fingerprint is supplied, that is the only parameter that will be used.
+    The only way to have full idempotency, is by having the fingerprint.
+
+    The other checks will not be completely idempotent.
 
     :param isamAppliance:
-    :param comment:
+    :param name:
     :return:
     """
     ret_obj = get_all(isamAppliance)
-
-    if uuid != None:
-        for name in ret_obj['data']:
-            if name['uuid'] == uuid:
+    # Fingerprint rules
+    if fingerprint:
+        for sshkeys in ret_obj['data']:
+            if sshkeys.get('fingerprint') == fingerprint:
+                logger.debug(f"Fingerprint matched on {sshkeys.get('name')} for the admin user")
                 return True
 
+    if name:
+        for sshkeys in ret_obj['data']:
+            if sshkeys.get('name') == name:
+                logger.debug(f"Name found on {sshkeys.get('name')} for the admin user")
+                return True
     return False
 
 

--- a/ibmsecurity/isam/base/sysaccount/ssh_keys.py
+++ b/ibmsecurity/isam/base/sysaccount/ssh_keys.py
@@ -20,7 +20,7 @@ def get(isamAppliance, user, name=None, uuid=None, check_mode=False, force=False
 
     """
     if uuid is not None and name is None:
-        return isamAppliance.invoke_get("Retrieving user", f"/sysaccount/users/{user}/ssh-keys/{uuid}/v1")
+        return isamAppliance.invoke_get("Retrieving key", f"/sysaccount/users/{user}/ssh-keys/{uuid}/v1")
     elif name is not None and uuid is None:
         # Get the key based on the name
         allKeys = get_all(isamAppliance, user)
@@ -29,7 +29,7 @@ def get(isamAppliance, user, name=None, uuid=None, check_mode=False, force=False
         # I expect we'll have 0 or 1 results now
         if uuids:
             uuid = uuids[0]
-            return isamAppliance.invoke_get("Retrieving user", f"/sysaccount/users/{user}/ssh-keys/{uuid}/v1")
+            return isamAppliance.invoke_get("Retrieving key", f"/sysaccount/users/{user}/ssh-keys/{uuid}/v1")
         else:
             return None
     else:

--- a/ibmsecurity/isam/base/sysaccount/ssh_keys.py
+++ b/ibmsecurity/isam/base/sysaccount/ssh_keys.py
@@ -1,5 +1,6 @@
 import logging
 import ibmsecurity.utilities.tools
+from ibmsecurity.appliance.ibmappliance import IBMError
 
 logger = logging.getLogger(__name__)
 
@@ -10,27 +11,42 @@ def get_all(isamAppliance, user, check_mode=False, force=False):
     """
     Get all SSH keys for a user
     """
-    return isamAppliance.invoke_get("Retrieving keys", "/sysaccount/users/{0}/ssh-keys/v1".format(user))
+    return isamAppliance.invoke_get("Retrieving keys", f"/sysaccount/users/{user}/ssh-keys/v1")
 
 
-def get(isamAppliance, user, uuid, check_mode=False, force=False):
+def get(isamAppliance, user, name=None, uuid=None, check_mode=False, force=False):
     """
     Get specific ssh key for a user
+
     """
-    return isamAppliance.invoke_get("Retrieving user", "/sysaccount/users/{0}/ssh-keys/{1}/v1".format(user, uuid))
+    if uuid is not None and name is None:
+        return isamAppliance.invoke_get("Retrieving user", f"/sysaccount/users/{user}/ssh-keys/{uuid}/v1")
+    elif name is not None and uuid is None:
+        # Get the key based on the name
+        allKeys = get_all(isamAppliance, user)
+        logger.debug(allKeys.get('data'))
+        uuids = [d.get('uuid') for d in allKeys.get('data') if d['name'] == name]
+        # I expect we'll have 0 or 1 results now
+        if uuids:
+            uuid = uuids[0]
+            return isamAppliance.invoke_get("Retrieving user", f"/sysaccount/users/{user}/ssh-keys/{uuid}/v1")
+        else:
+            return None
+    else:
+        # Input error
+        raise IBMError("999", "Cannot get the ssh keys.  Provide exactly 1 of the parameters uuid or name")
 
-
-def create(isamAppliance, user, key, name, check_mode=False, force=False):
+def add(isamAppliance, user, key, name, check_mode=False, force=False):
     """
     Import ssh key
     """
-    if force is True or _check(isamAppliance, user, key) is False:
+    if force or not _check(isamAppliance, user, name=name):
         if check_mode is True:
             return isamAppliance.create_return_object(changed=True, warnings=warnings)
         else:
             return isamAppliance.invoke_post(
                 "Import ssh key",
-                "/core/sysaccount/users/{0}/ssh-keys/v1".format(user),
+                f"/core/sysaccount/users/{user}/ssh-keys/v1",
                     {
                         'key': key,
                         'name': name
@@ -38,35 +54,94 @@ def create(isamAppliance, user, key, name, check_mode=False, force=False):
 
     return isamAppliance.create_return_object()
 
-
-def _check(isamAppliance, user=None, uuid=None):
+# alias for function add
+create = add
+def update(isamAppliance, user, key, name, check_mode=False, force=False):
     """
-    Check if the last created key has the exact same uuid or uuid exists
+    Update an existing key
+    """
+    # We know we need to do an update.  The only thing we can verify is that the comment is part
+    update_required = True
+    ret_obj = get(isamAppliance, user, name)
+    if not ret_obj:
+        # means we cannot find the name
+        logger.debug("Cannot find sshkeys by name")
+        update_required = False
+    elif key:
+        # Extract the comment from the new ssh public key
+        key_comment = key.split(' ')[-1]
+        logger.debug(f"See if {key_comment} for {user} is in an existing key")
+        if key_comment in ret_obj['data']['fingerprint']:
+            update_required = False
+
+    if check_mode is True:
+        return isamAppliance.create_return_object(changed=True, warnings=warnings)
+    elif update_required:
+        delete(isamAppliance, user, name)
+        return add(isamAppliance, user, key, name)
+
+    return isamAppliance.create_return_object()
+
+def set(isamAppliance, user, key, name, fingerprint=None, check_mode=False, force=False):
+    """
+    Create key if it does not exist yet, update if it does.
+
+    The fingerprint is the output format of ssh-keygen:  `ssh-keygen -l -f ~/.ssh/id_rsa.pub`
+    It is NOT used to send to ISVA, it is used to check if a key already exists.
+    """
+    if not _check(isamAppliance, user, name, fingerprint):
+        # Force the add - we already know there is no key by this name or fingerprint
+        return add(isamAppliance, user, key, name,
+                   check_mode=check_mode, force=True)
+    else:
+        # There is no update.  Let's see what this does.
+        return update(isamAppliance, user=user, key=key, name=name, check_mode=check_mode, force=force)
+
+def _check(isamAppliance, user=None, name=None, fingerprint=None):
+    """
+    The fingerprint is generated from the actual public key, using `ssh-keygen -l -f ~/.ssh/id_rsa.pub`
+    I'm unsure how to do this in Python, but I'm adding it to the check anyway (because Ansible)
+
+    If a fingerprint is supplied, that is the only parameter that will be used.
+    The only way to have full idempotency, is by having the fingerprint.
+
+    The other checks will not be completely idempotent.
 
     :param isamAppliance:
-    :param comment:
+    :param user:
+    :param name:
     :return:
     """
     ret_obj = get_all(isamAppliance, user)
-
-    if uuid != None:
-        for users in ret_obj['data']:
-            if users['uuid'] == uuid:
+    # Fingerprint rules
+    if fingerprint:
+        for sshkeys in ret_obj['data']:
+            if sshkeys.get('fingerprint') == fingerprint:
+                logger.debug(f"Fingerprint matched on {sshkeys.get('name')} for {user}")
                 return True
 
+    if name:
+        for sshkeys in ret_obj['data']:
+            if sshkeys.get('name') == name:
+                logger.debug(f"Name found on {sshkeys.get('name')} for {user}")
+                return True
     return False
 
 
-def delete(isamAppliance, user, uuid, check_mode=False, force=False):
+def delete(isamAppliance, user, name=None, uuid=None, check_mode=False, force=False):
     """
     Delete a ssh_key
     """
-    if force is True or _check(isamAppliance, user, uuid=uuid) is True:
+    ret_obj = get(isamAppliance, user, name, uuid)
+
+    if force or ret_obj.get('data'):
         if check_mode is True:
             return isamAppliance.create_return_object(changed=True)
         else:
+            if not uuid:
+                uuid = ret_obj.get('data').get('uuid')
             return isamAppliance.invoke_delete("Deleting key",
-            "/sysaccount/users/{0}/ssh-keys/{1}/v1".format(user, uuid))
+                f"/sysaccount/users/{user}/ssh-keys/{uuid}/v1")
 
     return isamAppliance.create_return_object()
 

--- a/ibmsecurity/isam/base/sysaccount/ssh_keys.py
+++ b/ibmsecurity/isam/base/sysaccount/ssh_keys.py
@@ -67,7 +67,7 @@ def update(isamAppliance, user, key, name, check_mode=False, force=False):
     if not ret_obj:
         # means we cannot find the name
         logger.debug(f"Cannot find sshkeys by name ({name}).  This happens when we had a match on fingerprint (not on name)")
-        warnings.append(f"This publi key ({name}) is already there by another name.")
+        warnings.append(f"This public key ({name}) is already there by another name.")
         update_required = False
     elif key:
         # Extract the comment from the new ssh public key


### PR DESCRIPTION
    p(ibmsecurity.isam.base.sysaccount.ssh_keys.set(isamAppliance=isam_server, user='sshtom', name='test2', key='ssh-ed25519 SSHPUBKEY something'))

    p(ibmsecurity.isam.base.admin_ssh_keys.set(isamAppliance=isam_server, name='mykey',
                                                    key='ssh-ed25519 SSHPUBKEY  admin2'))
