### PR TITLE
removed the extra curly braces from get_config_data function

### DIFF
--- a/ibmsecurity/isam/base/extensions.py
+++ b/ibmsecurity/isam/base/extensions.py
@@ -205,7 +205,7 @@ def _get_config_data(extId, config_data):
     if config_data is None:
         return json.dumps({extId: extId})
     if isinstance(config_data, basestring):
-        return '{extId:}' + extId + ',' + config_data + '}'
+        return '{extId:' + extId + ',' + config_data + '}'
     config_data['extId'] = extId
     return json.dumps(config_data)
 


### PR DESCRIPTION
def _get_config_data(extId, config_data):

"""

Generate a JSON payload for activate/update

"""

if config_data is None:

   return json.dumps({extId: extId}) >>> **Should be return json.dumps({'extId': extId})** 
if isinstance(config_data, basestring):

   return '{extId:}' + extId + ',' + config_data + '}'  >>> **should be return '{extId:' + extId + ',' + config_data + '}'**
config_data['extId'] = extId

return json.dumps(config_data)