### PR TITLE
416 multiple vulnerabilities found in ibmsecurity

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+# 2024.4.5.0
+
+- fix: update stanza.py (#414)
+- fix: remove curly braces from get_config_data function (#417)
+- security fix: enable verify ssl (V-94) (#416)
+- security fix: show a warning about not verifying tls for connections to the LMI (V-93) (#416)
+- security fix: remove hardcoded usernames and passwords (V-95) (#416)
+- security fix: uninitialized variables (V-96) (#416)
+- documentation: update readme with info on how to handle the tls verification
+
 ## 2024.2.26.0
 
 - feature: set_all function for reverse proxy junctions

--- a/ibmsecurity/appliance/ibmappliance.py
+++ b/ibmsecurity/appliance/ibmappliance.py
@@ -44,8 +44,7 @@ class IBMResponse(dict):
         return True
 
 
-class IBMAppliance:
-    __metaclass__ = ABCMeta
+class IBMAppliance(metaclass=ABCMeta):
 
     def __init__(self, hostname, user):
         self.logger = logging.getLogger(__name__)

--- a/ibmsecurity/appliance/isamappliance.py
+++ b/ibmsecurity/appliance/isamappliance.py
@@ -402,9 +402,9 @@ See the following URL for more details:
         try:
             if func == self.session.get or func == self.session.delete:
                 if data != {}:
-                    r = func(url=self._url(uri), data=json_data, headers=headers)
+                    r = func(url=self._url(uri), data=json_data, headers=headers, verify=self.verify)
                 else:
-                    r = func(url=self._url(uri), headers=headers)
+                    r = func(url=self._url(uri), headers=headers, verify=self.verify)
             else:
                 r = func(url=self._url(uri), data=json_data,
                          headers=headers, verify=self.verify, cert=self.cert)

--- a/ibmsecurity/appliance/isamappliance.py
+++ b/ibmsecurity/appliance/isamappliance.py
@@ -94,7 +94,7 @@ See the following URL for more details:
 
     def _process_response(self, return_obj, http_response, ignore_error):
 
-        return_obj['rsp'] = http_response
+        # return_obj['rsp'] = http_response # Do not add this - breaks the ISAM Collection's connection
         return_obj['rc'] = http_response.status_code
 
         # Examine the response.

--- a/ibmsecurity/appliance/isamappliance.py
+++ b/ibmsecurity/appliance/isamappliance.py
@@ -1,5 +1,6 @@
 import json
 import requests
+import traceback
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
 import logging
 from .ibmappliance import IBMAppliance
@@ -111,7 +112,7 @@ See the following URL for more details:
             if http_response.text != "":
                 self.logger.error("     text: " + http_response.text)
             if not ignore_error:
-                raise IBMError("HTTP Return code: {0}".format(http_response.status_code), http_response.text, http_response)
+                raise IBMError("HTTP Return code: {0}".format(http_response.status_code), http_response.text)
             return_obj['changed'] = False  # force changed to be False as there is an error
         else:
             return_obj['rc'] = 0
@@ -157,7 +158,7 @@ See the following URL for more details:
             self.logger.critical("Failed to connect to server.")
             raise IBMError("HTTP Return code: 502", "Failed to connect to server")
         else:
-            if self.debug: self.logger.debug("Failed to connect to server.")
+            self.logger.debug("Failed to connect to server.")
             return_obj['rc'] = 502
 
     def _process_warnings(self, uri, requires_modules, requires_version, requires_model, warnings=[]):
@@ -342,7 +343,7 @@ See the following URL for more details:
                 if r.text != "":
                     self.logger.error("     text: " + r.text)
                 if not ignore_error:
-                    raise IBMError("HTTP Return code: {0}".format(r.status_code), r.text, r)
+                    raise IBMError("HTTP Return code: {0}".format(r.status_code), r.text)
                 else:
                     return_obj['rc'] = r.status_code
                     return_obj['data'] = {'msg': 'Unable to extract contents to file!'}
@@ -525,7 +526,7 @@ See the following URL for more details:
                 self.logger.critical("Failed to connect to server.")
                 raise IBMError("HTTP Return code: 502", "Failed to connect to server")
             else:
-                if self.debug: self.logger.debug("Failed to connect to server.")
+                self.logger.debug("Failed to connect to server.")
                 return_obj.rc = 502
 
         return return_obj
@@ -632,7 +633,7 @@ See the following URL for more details:
                         if r.text != "":
                             self.logger.error("     text: " + r.text)
                         if not ignore_error:
-                            raise IBMError("HTTP Return code: {0}".format(r.status_code), r.text, r)
+                            raise IBMError("HTTP Return code: {0}".format(r.status_code), r.text)
                         else:
                             return_obj['rc'] = r.status_code
                             return_obj['data'] = {'msg': 'Unable to extract contents to file!'}
@@ -741,14 +742,14 @@ See the following URL for more details:
                 self.facts['activations'].append(activation['id'])
 
     def _log_request(self, method, url, desc):
-        if self.debug: self.logger.debug("Request: %s %s desc=%s", method, url, desc)
+        self.logger.debug("Request: %s %s desc=%s", method, url, desc)
 
     def _log_response(self, response):
         if response:
-            if self.debug: self.logger.debug("Response: %d", response.get('rc'))
+            self.logger.debug("Response: %d", response.get('rc'))
             # self.logger.debug("Response: %i %i warnings:%s",
             #                     response.get('rc'),
             #                     response.get('status_code'),
             #                     response.get('warnings'))
         else:
-            if self.debug: self.logger.debug("Response: None")
+            self.logger.debug("Response: None")

--- a/ibmsecurity/appliance/isamappliance_adminproxy.py
+++ b/ibmsecurity/appliance/isamappliance_adminproxy.py
@@ -17,7 +17,7 @@ class ISAMApplianceAdminProxy(ISAMAppliance):
         self.adminProxyHostname = adminProxyHostname
 
         # Type checking and tranformation to safely reuse this variable later on
-        if isinstance(adminProxyPort, basestring):
+        if isinstance(adminProxyPort, str):
             self.adminProxyPort = int(adminProxyPort)
         else:
             self.adminProxyPort = adminProxyPort

--- a/ibmsecurity/appliance/isdsappliance.py
+++ b/ibmsecurity/appliance/isdsappliance.py
@@ -7,6 +7,7 @@ from .ibmappliance import IBMError
 from .ibmappliance import IBMFatal
 from ibmsecurity.utilities import tools
 from io import open
+from os import environ
 
 try:
     basestring
@@ -15,15 +16,56 @@ except NameError:
 
 
 class ISDSAppliance(IBMAppliance):
-    def __init__(self, hostname, user, lmi_port=443, verify=False):
+    def __init__(self, hostname, user, lmi_port=443, verify=None):
         self.logger = logging.getLogger(__name__)
         self.logger.debug('Creating an ISDSAppliance')
         if isinstance(lmi_port, basestring):
             self.lmi_port = int(lmi_port)
         else:
             self.lmi_port = lmi_port
-        self.verify = verify
+        self.hostname = hostname
+        self.session = requests.session()
+
+        # If we did not get a value for verify, try the environment variable
+        if verify is None:
+            verify = str(environ.get("IBMSECLIB_VERIFY_CONNECTION", False)).lower() in ["true", "yes"]
+
+        self.cert = cert
+
+        self.disable_urllib_warnings = False
+        if self.cert is None:
+            self.logger.debug('Cert object is None, using BA Auth with userid/password.')
+            self.session.auth = (user.username, user.password)
+        else:
+            self.logger.debug('Using cert based auth, since cert object is not None.')
+            self.session.cert = self.cert
+
+        self._set_ssl_verification(requests_verify_param=verify)
+
         IBMAppliance.__init__(self, hostname, user)
+
+    def _set_ssl_verification(self, requests_verify_param):
+        self.verify = requests_verify_param
+        self.session.verify = self.verify
+        if self.verify is None or self.verify is False:
+            self.disable_urllib_warnings = True
+            self.logger.warning("""
+Certificate verification has been disabled. Python is NOT verifying the SSL 
+certificate of the host appliance and InsecureRequestWarning messages are 
+being suppressed for the following host:
+  https://{0}:{1}
+
+To use certificate verification:
+  1. When the certificate is trusted by your Python environment:
+        Instantiate all instances of ISDSAppliance with verify=True or set 
+        the environment variable IBMSECLIB_VERIFY_CONNECTION=True.
+  2. When the certificate is not already trusted in your Python environment:
+        Instantiate all instances of ISAMAppliance with the verify parameter
+        set to the fully qualified path to a CA bundle.
+        
+See the following URL for more details:
+  https://requests.readthedocs.io/en/latest/user/advanced/#ssl-cert-verification
+""".format(self.hostname, self.lmi_port))
 
     def _url(self, uri):
         # Build up the URL
@@ -37,10 +79,11 @@ class ISDSAppliance(IBMAppliance):
             self.logger.info('*** ' + description + ' ***')
 
     def _suppress_ssl_warning(self):
-        # Don't suppress ssl warnings if verifying ssl certificates is enabled.
-        # The ssl warnings are disabled, but there's still a warning shown.
-        if self.verify:
+        # If we have trust setup correctly, we do not want to suppress these warnings.
+        if not self.disable_urllib_warnings:
             return
+
+        # Disable https warning because of non-standard certs on appliance
         try:
             self.logger.warning("Suppressing SSL Warnings.")
             requests.packages.urllib3.disable_warnings(InsecureRequestWarning)

--- a/ibmsecurity/appliance/isvgappliance.py
+++ b/ibmsecurity/appliance/isvgappliance.py
@@ -4,25 +4,25 @@ from requests.packages.urllib3.exceptions import InsecureRequestWarning
 import logging
 from .ibmappliance import IBMAppliance
 from .ibmappliance import IBMError
+from .ibmappliance import IBMFatal
 from ibmsecurity.utilities import tools
 from io import open
 
 try:
     basestring
 except NameError:
-
     basestring = (str, bytes)
 
 
 class ISVGAppliance(IBMAppliance):
-    def __init__(self, hostname, user, lmi_port=443):
+    def __init__(self, hostname, user, lmi_port=443, verify=False):
         self.logger = logging.getLogger(__name__)
         self.logger.debug('Creating an ISVGAppliance')
         if isinstance(lmi_port, basestring):
             self.lmi_port = int(lmi_port)
         else:
             self.lmi_port = lmi_port
-
+        self.verify = verify
         IBMAppliance.__init__(self, hostname, user)
 
     def _url(self, uri):
@@ -37,24 +37,28 @@ class ISVGAppliance(IBMAppliance):
             self.logger.info('*** ' + description + ' ***')
 
     def _suppress_ssl_warning(self):
-        # Disable https warning because of non-standard certs on appliance
+        # Don't suppress ssl warnings if verifying ssl certificates is enabled.
+        # The ssl warnings are disabled, but there's still a warning shown.
+        if self.verify:
+            return
         try:
-            self.logger.debug("Suppressing SSL Warnings.")
+            self.logger.warning("Suppressing SSL Warnings.")
             requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
         except AttributeError:
             self.logger.warning("load requests.packages.urllib3.disable_warnings() failed")
 
     def _process_response(self, return_obj, http_response, ignore_error):
 
+        return_obj['rsp'] = http_response
         return_obj['rc'] = http_response.status_code
 
         # Examine the response.
         if (http_response.status_code == 302):
-            self.logger.warning("  Endpoint cannot be use at this time: ")
+            self.logger.warning("  Endpoint cannot be used at this time: ")
             self.logger.warning("     status code: {0}".format(http_response.status_code))
             if http_response.text != "":
                 self.logger.error("     text: " + http_response.text)
-            # Too early to use this endppoint.
+            # Too early to use this endpoint.
             return_obj['changed'] = False
             return_obj['rc'] = 0
         elif (http_response.status_code != 200 and http_response.status_code != 204 and http_response.status_code != 201):
@@ -69,6 +73,7 @@ class ISVGAppliance(IBMAppliance):
             return_obj['rc'] = 0
 
         # Handle if there was json on input but response was not in json format
+        json_data = {}
         try:
             json_data = json.loads(http_response.text)
         except ValueError:
@@ -86,9 +91,7 @@ class ISVGAppliance(IBMAppliance):
                     return_obj.data = http_response.content
                     return
 
-        if http_response.text == "":
-            json_data = {}
-        else:
+        if http_response.text != "":
             json_data = json.loads(http_response.text)
 
         return_obj['data'] = json_data
@@ -175,7 +178,7 @@ class ISVGAppliance(IBMAppliance):
 
         try:
             r = requests.post(url=self._url(uri=uri), data=data, auth=(self.user.username, self.user.password),
-                              files=files, verify=False, headers=headers)
+                              files=files, verify=self.verify, headers=headers)
             return_obj['changed'] = True  # POST of file would be a change
             self._process_response(return_obj=return_obj, http_response=r, ignore_error=ignore_error)
 
@@ -219,7 +222,7 @@ class ISVGAppliance(IBMAppliance):
 
         try:
             r = requests.put(url=self._url(uri=uri), data=data, auth=(self.user.username, self.user.password),
-                             files=files, verify=False, headers=headers)
+                             files=files, verify=self.verify, headers=headers)
             return_obj['changed'] = True  # POST of file would be a change
             self._process_response(return_obj=return_obj, http_response=r, ignore_error=ignore_error)
 
@@ -263,7 +266,7 @@ class ISVGAppliance(IBMAppliance):
         self._suppress_ssl_warning()
 
         try:
-            r = requests.get(url=self._url(uri=uri), auth=(self.user.username, self.user.password), verify=False,
+            r = requests.get(url=self._url(uri=uri), auth=(self.user.username, self.user.password), verify=self.verify,
                              stream=True, headers=headers, allow_redirects=False)
 
             if (r.status_code != 200 and r.status_code != 204 and r.status_code != 201):
@@ -331,14 +334,14 @@ class ISVGAppliance(IBMAppliance):
 
                 if data != {}:
                     r = func(url=self._url(uri), data=json_data, auth=(self.user.username, self.user.password),
-                             verify=False, headers=headers, allow_redirects=False)
+                             verify=self.verify, headers=headers, allow_redirects=False)
                 else:
                     r = func(url=self._url(uri), auth=(self.user.username, self.user.password),
-                             verify=False, headers=headers, allow_redirects=False)
+                             verify=self.verify, headers=headers, allow_redirects=False)
             else:
                 r = func(url=self._url(uri), data=json_data,
                          auth=(self.user.username, self.user.password),
-                         verify=False, headers=headers)
+                         verify=self.verify, headers=headers)
 
             if func != requests.get:
                 return_obj['changed'] = True  # Anything but GET should result in change

--- a/ibmsecurity/isam/aac/attribute_matchers.py
+++ b/ibmsecurity/isam/aac/attribute_matchers.py
@@ -101,6 +101,7 @@ def _check(isamAppliance, description, properties):
     """
     update_required = False
     ret_obj = get(isamAppliance, description)
+    json_data = {}
     if ret_obj['data'] == {}:
         logger.warning("Attribute Matcher not found, returning no update required.")
         return None, update_required, json_data

--- a/ibmsecurity/isam/aac/risk_profiles.py
+++ b/ibmsecurity/isam/aac/risk_profiles.py
@@ -155,6 +155,7 @@ def _check(isamAppliance, name, active, description, attributes, predefined):
     """
     update_required = False
     ret_obj = get(isamAppliance, name)
+    json_data = {}
     if ret_obj['data'] == {}:
         logger.warning("Risk Profile not found, returning no update required.")
         return None, update_required, json_data

--- a/ibmsecurity/isam/web/reverse_proxy/aac_configuration.py
+++ b/ibmsecurity/isam/web/reverse_proxy/aac_configuration.py
@@ -6,7 +6,7 @@ requires_modules = ["wga"]
 requires_version = "9.0.6.0"
 
 
-def config(isamAppliance, instance_id, hostname='127.0.0.1', port=443, username='easuser', password='passw0rd',
+def config(isamAppliance, instance_id, hostname='127.0.0.1', port=443, username=None, password=None,
            junction="/mga", reuse_certs=False, reuse_acls=False, check_mode=False, force=False):
     """
     Authentication and Context based access configuration for a reverse proxy instance
@@ -24,6 +24,13 @@ def config(isamAppliance, instance_id, hostname='127.0.0.1', port=443, username=
     :param force:
     :return:
     """
+    if username is None:
+        logger.info("Required parameter username missing. Skipping config.")
+        return isamAppliance.create_return_object(warning=["Required parameter username missing. Skipping config."])
+
+    if password is None:
+        logger.info("Required parameter password missing. Skipping config.")
+        return isamAppliance.create_return_object(warning=["Required parameter password missing. Skipping config."])
     warnings = [
         "Idempotency logic will check for existence of {} junction. Use force=True to override.".format(junction)]
     if force is True or _check_config(isamAppliance, instance_id, junction) is False:

--- a/ibmsecurity/isam/web/reverse_proxy/federation_configuration.py
+++ b/ibmsecurity/isam/web/reverse_proxy/federation_configuration.py
@@ -25,11 +25,11 @@ def config(isamAppliance, instance_id, federation_id=None, federation_name=None,
     """
     if username is None:
         logger.info("Required parameter username missing. Skipping config.")
-        return isamAppliance.create_return_object()
+        return isamAppliance.create_return_object(warning=["Required parameter username missing. Skipping config."])
 
     if password is None:
         logger.info("Required parameter password missing. Skipping config.")
-        return isamAppliance.create_return_object()
+        return isamAppliance.create_return_object(warning=["Required parameter password missing. Skipping config."])
 
     if federation_name is not None:
         ret_obj = ibmsecurity.isam.fed.federations.search(isamAppliance, name=federation_name, check_mode=check_mode,

--- a/ibmsecurity/isam/web/reverse_proxy/federation_configuration.py
+++ b/ibmsecurity/isam/web/reverse_proxy/federation_configuration.py
@@ -4,8 +4,8 @@ import ibmsecurity.isam.fed.federations
 logger = logging.getLogger(__name__)
 
 
-def config(isamAppliance, instance_id, federation_id=None, federation_name=None, hostname='127.0.0.1', port='443', username='easuser',
-           password='passw0rd', reuse_certs=False, reuse_acls=False, check_mode=False, force=False):
+def config(isamAppliance, instance_id, federation_id=None, federation_name=None, hostname='127.0.0.1', port='443', username=None,
+           password=None, reuse_certs=False, reuse_acls=False, check_mode=False, force=False):
     """
     Federation configuration for a reverse proxy instance
 
@@ -23,6 +23,13 @@ def config(isamAppliance, instance_id, federation_id=None, federation_name=None,
     :param force:
     :return:
     """
+    if username is None:
+        logger.info("Required parameter username missing. Skipping config.")
+        return isamAppliance.create_return_object()
+
+    if password is None:
+        logger.info("Required parameter password missing. Skipping config.")
+        return isamAppliance.create_return_object()
 
     if federation_name is not None:
         ret_obj = ibmsecurity.isam.fed.federations.search(isamAppliance, name=federation_name, check_mode=check_mode,

--- a/ibmsecurity/isam/web/reverse_proxy/oauth_configuration.py
+++ b/ibmsecurity/isam/web/reverse_proxy/oauth_configuration.py
@@ -7,7 +7,7 @@ requires_modules = ["wga"]
 requires_version = "9.0.4.0"
 
 
-def config(isamAppliance, instance_id, hostname='127.0.0.1', port=443, username='easuser', password='passw0rd',
+def config(isamAppliance, instance_id, hostname='127.0.0.1', port=443, username=None, password=None,
            junction="/mga", reuse_certs=False, reuse_acls=False, api=False, browser=False, auth_register=None, fapi_compliant=None,
            check_mode=False, force=False):
     """
@@ -30,6 +30,14 @@ def config(isamAppliance, instance_id, hostname='127.0.0.1', port=443, username=
     :param fapi_compliant:
     :return:
     """
+    if username is None:
+        logger.info("Required parameter username missing. Skipping config.")
+        return isamAppliance.create_return_object(warning=["Required parameter username missing. Skipping config."])
+
+    if password is None:
+        logger.info("Required parameter password missing. Skipping config.")
+        return isamAppliance.create_return_object(warning=["Required parameter password missing. Skipping config."])
+
     warnings = [
         "Idempotency logic will check for existence of {} junction. Use force=True to override.".format(junction)]
     if force is True or _check_config(isamAppliance, instance_id, junction) is False:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ibmsecurity"
-version = "2024.2.26.0"
+version = "2024.4.5.0"
 authors = [
   { name="IBM", email="secorch@wwpdl.vnet.ibm.com" },
 ]

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     packages = find_packages(),
     # Date of release used for version - please be sure to use YYYY.MM.DD.seq#, MM and DD should be two digits e.g. 2017.02.05.0
     # seq# will be zero unless there are multiple release on a given day - then increment by one for additional release for that date
-    version = '2024.2.26.0',
+    version = '2024.4.5.0',
     description = 'Idempotent functions for IBM Security Appliance REST APIs',
     author='IBM',
     author_email='secorch@wwpdl.vnet.ibm.com',


### PR DESCRIPTION
- security fix: enable verify ssl (V-94) (#416)
- security fix: show a warning about not verifying tls for connections to the LMI (V-93) (#416)
- security fix: remove hardcoded usernames and passwords (V-95) (#416)
- security fix: uninitialized variables (V-96) (#416)
- documentation: update readme with info on how to handle the tls verification