### PR TITLE
Fix/419 warnings not initialised

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,8 @@
 # Manual change log
 
 ## Unreleased
+- fix: uninitialized 'warnings' variable in junctions_server.py (#419)
+- fix: add preserve_label in signer_certificates (from kg)
 
 # 2024.4.5.0
 

--- a/ibmsecurity/isam/web/reverse_proxy/junctions_server.py
+++ b/ibmsecurity/isam/web/reverse_proxy/junctions_server.py
@@ -30,7 +30,7 @@ def get(isamAppliance, reverseproxy_id, junction_point, server_hostname, server_
             break
     return ret_obj_new
 
-def add(isamAppliance, reverseproxy_id, junction_point, server_hostname, server_port, junction_type="tcp", check_mode=False, force=False,
+def add(isamAppliance, reverseproxy_id, junction_point, server_hostname, server_port, junction_type="tcp", check_mode=False, force=False, warnings=[],
         **optionargs):
     """
     Adding a back-end server to an existing standard or virtual junctions


### PR DESCRIPTION
- fix: uninitialized 'warnings' variable in junctions_server.py (#419)
- fix: add preserve_label in signer_certificates (from kg)