### PR TITLE
fix: issue #454: isam.web.reverse_proxy.configuration.entry.set throws AttributeError when entries list is empty.

### DIFF
--- a/ibmsecurity/isam/web/reverse_proxy/configuration/entry.py
+++ b/ibmsecurity/isam/web/reverse_proxy/configuration/entry.py
@@ -141,7 +141,7 @@ def _collapse_entries_obj(entries):
    Also converts all values to str for easy compare
    """
     if entries is None or len(entries) < 1:
-        return []
+        return {}
     else:
         prev_key = ""
         new_entry = {}


### PR DESCRIPTION
Change return type of _collapse_entries_obj to an empty dictionary